### PR TITLE
Live build logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.1",
  "brotli",
  "bytes",
@@ -63,7 +63,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.11",
  "httparse",
  "httpdate",
  "itoa",
@@ -98,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
 dependencies = [
  "bytestring",
- "http",
+ "http 0.2.11",
  "regex",
  "serde",
  "tracing",
@@ -199,6 +199,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "actix-web-lab"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7675c1a84eec1b179c844cdea8488e3e409d8e4984026e92fa96c87dd86f33c6"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "actix-web-lab-derive",
+ "ahash",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytestring",
+ "csv",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "http 0.2.11",
+ "impl-more",
+ "itertools 0.12.1",
+ "local-channel",
+ "mediatype",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "actix-web-lab-derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa0b287c8de4a76b691f29dbb5451e8dd5b79d777eaf87350c9b0cbfdb5e968"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -339,6 +388,12 @@ name = "anyhow"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-channel"
@@ -573,6 +628,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,14 +685,14 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bollard-stubs",
  "bytes",
  "futures-core",
  "futures-util",
  "hex",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "hyperlocal",
  "log",
  "pin-project-lite",
@@ -987,6 +1048,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
  "pin-project-lite",
 ]
 
@@ -1318,6 +1411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1503,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -1506,13 +1605,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1551,8 +1684,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1565,17 +1698,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1586,7 +1758,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.27",
  "pin-project",
  "tokio",
 ]
@@ -1639,6 +1811,12 @@ dependencies = [
  "walkdir",
  "winapi-util",
 ]
+
+[[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "indexmap"
@@ -1857,6 +2035,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "mediatype"
+version = "0.19.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878cd8d1b3c8c8ae4b2ba0a36652b7cf192f618a599a7fbdfa25cffd4ea72dd"
 
 [[package]]
 name = "memchr"
@@ -2243,7 +2427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dafb3f375eedbb68b8c57a79cb220171ad1b716196fa35d4ab059f5fda21cc17"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_derive",
 ]
@@ -2301,15 +2485,15 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.27",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -2332,7 +2516,60 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest 0.12.4",
+ "thiserror",
 ]
 
 [[package]]
@@ -2498,7 +2735,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2575,6 +2812,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.1.0",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,7 +2864,7 @@ version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2655,6 +2905,7 @@ version = "0.3.0"
 dependencies = [
  "actix-files",
  "actix-web",
+ "actix-web-lab",
  "anyhow",
  "async-std",
  "async-tar",
@@ -2665,7 +2916,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-util",
- "hyper",
+ "hyper 0.14.27",
  "lazy_static",
  "log",
  "raur",
@@ -2676,6 +2927,7 @@ dependencies = [
  "srcinfo",
  "tokio",
  "tokio-cron-scheduler",
+ "tokio-stream",
  "tokio-util",
  "typetag",
  "uuid",
@@ -2691,13 +2943,16 @@ dependencies = [
  "clap_complete",
  "colored",
  "cron-descriptor",
+ "futures",
  "rand",
- "reqwest",
+ "reqwest 0.11.23",
+ "reqwest-eventsource",
  "serde",
  "serde_json",
  "serde_yaml 0.9.29",
  "serene-data",
  "terminal_size",
+ "tokio",
  "whoami",
 ]
 
@@ -2705,7 +2960,7 @@ dependencies = [
 name = "serene-data"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "serde",
  "sha2",
@@ -2929,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.1",
  "byteorder",
  "bytes",
@@ -2972,7 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.1",
  "byteorder",
  "chrono",
@@ -3127,6 +3382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,9 +3517,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3311,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3343,6 +3604,28 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -3638,6 +3921,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +4136,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,3 +30,6 @@ rand = "0.8.5"
 # web, TODO: for some reason, when this builds with openssl (i.e. not rustls), the server does too, which causes problems with the container. WHYYY?
 reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 chrono = { version = "0.4.31", features = ["serde"] }
+reqwest-eventsource = { version = "0.6.0" }
+futures = "0.3.30"
+tokio = "1.37.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,7 +45,7 @@ serene info my-package pkgbuild
 # See more information about the latest build. Supply an id for a specific one.
 serene info my-package build
 
-# See the logs of the latest build. Supply an id for a specific one. Add `--subscribe` to get live logs.
+# See the logs of the latest build. Supply an id for a specific one. Add `--subscribe` to get live logs and `--attach` to attach to live logs.
 serene info my-package logs
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,7 +45,7 @@ serene info my-package pkgbuild
 # See more information about the latest build. Supply an id for a specific one.
 serene info my-package build
 
-# See the logs of the latest build. Supply an id for a specific one. Add `--subscribe` to get live logs and `--attach` to attach to live logs.
+# See the logs of the latest build. Supply an id for a specific one. Add `--subscribe` to get live logs until next build is finished and `--linger` to indefinitely attach to live logs.
 serene info my-package logs
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,7 +45,7 @@ serene info my-package pkgbuild
 # See more information about the latest build. Supply an id for a specific one.
 serene info my-package build
 
-# See the logs of the latest build. Supply an id for a specific one.
+# See the logs of the latest build. Supply an id for a specific one. Add `--subscribe` to get live logs.
 serene info my-package logs
 ```
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -93,9 +93,13 @@ pub enum InfoCommand {
         /// id of the build, latest if empty
         id: Option<String>,
 
-        /// subscribe and attach to live logs
+        /// subscribe to live logs
         #[clap(short, long)]
-        subscribe: Option<bool>
+        subscribe: Option<bool>,
+
+        /// stay attached to live logs
+        #[clap(short, long, requires("subscribe"))]
+        attach: Option<bool>
     },
 
     /// get the pkgbuild used to build the current package

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -91,7 +91,11 @@ pub enum InfoCommand {
     /// get logs from a build
     Logs {
         /// id of the build, latest if empty
-        id: Option<String>
+        id: Option<String>,
+
+        /// subscribe and attach to live logs
+        #[clap(short, long)]
+        subscribe: Option<bool>
     },
 
     /// get the pkgbuild used to build the current package

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -93,13 +93,13 @@ pub enum InfoCommand {
         /// id of the build, latest if empty
         id: Option<String>,
 
-        /// subscribe to live logs
+        /// subscribe to live logs until next build is finished
         #[clap(short, long)]
-        subscribe: Option<bool>,
+        subscribe: bool,
 
-        /// stay attached to live logs
-        #[clap(short, long, requires("subscribe"))]
-        attach: Option<bool>
+        /// indefinitely stay attached to live logs
+        #[clap(short, long)]
+        linger: bool
     },
 
     /// get the pkgbuild used to build the current package

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,7 +64,13 @@ fn main() -> anyhow::Result<()> {
                 None => { requests::info(&config, &name, all); }
                 Some(InfoCommand::Pkgbuild) => { requests::pkgbuild(&config, &name); }
                 Some(InfoCommand::Build { id }) => { requests::build_info(&config, &name, &id); }
-                Some(InfoCommand::Logs { id }) => { requests::build_logs(&config, &name, &id); }
+                Some(InfoCommand::Logs { id, subscribe }) => { 
+                    if subscribe.is_some() {
+                        requests::subscribe_build_logs(&config, &name)
+                    } else {
+                        requests::build_logs(&config, &name, &id); 
+                    }
+                }
                 Some(InfoCommand::Set { property }) => { requests::set_setting(&config, &name, property) }
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,11 +64,11 @@ fn main() -> anyhow::Result<()> {
                 None => { requests::info(&config, &name, all); }
                 Some(InfoCommand::Pkgbuild) => { requests::pkgbuild(&config, &name); }
                 Some(InfoCommand::Build { id }) => { requests::build_info(&config, &name, &id); }
-                Some(InfoCommand::Logs { id, subscribe, attach }) => { 
-                    if subscribe.is_some() {
-                        requests::subscribe_build_logs(&config, attach.unwrap_or_default(), &name)
-                    } else {
+                Some(InfoCommand::Logs { id, subscribe, linger }) => { 
+                    if id.is_some() {
                         requests::build_logs(&config, &name, &id); 
+                    } else {
+                        requests::subscribe_build_logs(&config, linger, subscribe, &name)
                     }
                 }
                 Some(InfoCommand::Set { property }) => { requests::set_setting(&config, &name, property) }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,9 +64,9 @@ fn main() -> anyhow::Result<()> {
                 None => { requests::info(&config, &name, all); }
                 Some(InfoCommand::Pkgbuild) => { requests::pkgbuild(&config, &name); }
                 Some(InfoCommand::Build { id }) => { requests::build_info(&config, &name, &id); }
-                Some(InfoCommand::Logs { id, subscribe }) => { 
+                Some(InfoCommand::Logs { id, subscribe, attach }) => { 
                     if subscribe.is_some() {
-                        requests::subscribe_build_logs(&config, &name)
+                        requests::subscribe_build_logs(&config, attach.unwrap_or_default(), &name)
                     } else {
                         requests::build_logs(&config, &name, &id); 
                     }

--- a/cli/src/web/mod.rs
+++ b/cli/src/web/mod.rs
@@ -120,7 +120,7 @@ pub fn get<R: DeserializeOwned>(config: &Config, path: &str) -> Result<R> {
     process_result(result)
 }
 
-pub fn eventsource<F>(config: &Config, path: &str, cb: F) -> Result<()> where F: Fn(Event) {
+pub fn eventsource<F>(config: &Config, path: &str, mut cb: F) -> Result<()> where F: FnMut(Event) {
     let full_path = format!("{path}?auth={}", config.secret);
     let mut con = reqwest_eventsource::EventSource::get(get_url(config, full_path.as_str()));
 

--- a/cli/src/web/requests.rs
+++ b/cli/src/web/requests.rs
@@ -1,3 +1,4 @@
+use std::process::exit;
 use std::str::FromStr;
 use chrono::{Local, Utc};
 use colored::{ColoredString, Colorize};
@@ -228,12 +229,18 @@ pub fn build_logs(c: &Config, package: &str, build: &Option<String>) {
     }
 }
 
-pub fn subscribe_build_logs(c: &Config, package: &str) {
+pub fn subscribe_build_logs(c: &Config, attach: bool, package: &str) {
     let Err(err) = eventsource(c, format!("package/{}/build/logs/subscribe", package).as_str(), |event| {
         if let Event::Message(event) = event {
             match event.event.as_str() {
                 "build_start" => println!("\n{}", "New package build started".italic().dimmed()),
-                "build_end" => println!("\n{}", "Package build finished".italic().dimmed()),
+                "build_end" => {
+                    if !attach {
+                        exit(0);
+                    } else {
+                        println!("\n{}", "Package build finished".italic().dimmed())
+                    }
+                },
                 "log" => print!("{}", event.data),
                 _ => {}
             }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ srcinfo = "1.1.0"
 # async
 tokio = { version = "1.35.0", features = ["full"]}
 tokio-util = { version = "0.7.10", features = ["compat"]}
+tokio-stream = "0.1.15"
 
 futures = "0.3.29"
 futures-util = "0.3.29"
@@ -33,6 +34,7 @@ hyper = "0.14.27"
 # web
 actix-web = "4.4.0"
 actix-files = "0.6.2"
+actix-web-lab = "0.20.2"
 
 # storage
 serde = "1.0.193"

--- a/server/data/src/package.rs
+++ b/server/data/src/package.rs
@@ -115,3 +115,18 @@ pub struct PackageInfo {
     /// date added
     pub added: DateTime<Utc>,
 }
+
+/// All events which can be emitted by the broadcast for a package
+#[derive(Serialize, Deserialize, EnumString, Display, Clone)]
+#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+pub enum BroadcastEvent {
+    /// A build job for the package was started
+    BuildStart,
+    /// A build job for the package finished
+    BuildEnd,
+    /// Log message for the package build
+    Log,
+    /// Ping to the event subscriber
+    Ping
+}

--- a/server/src/build/mod.rs
+++ b/server/src/build/mod.rs
@@ -212,7 +212,7 @@ impl Builder {
 
         self.runner.read().await.upload_sources(&container, package).await?;
 
-        let status = self.runner.read().await.build(&container).await?;
+        let status = self.runner.read().await.build(&container, package).await?;
 
         Ok((status, container))
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     let db = database::connect().await?;
     
     // initialize broadcast
-    let broadcast = Broadcast::new(db.clone());
+    let broadcast = Broadcast::new();
     
     // initializing runner
     let runner = Arc::new(RwLock::new(

--- a/server/src/runner/mod.rs
+++ b/server/src/runner/mod.rs
@@ -2,6 +2,8 @@ pub mod archive;
 
 use std::error::Error;
 use std::io::Read;
+use std::sync::Arc;
+use std::vec;
 use anyhow::{Context};
 use async_tar::Archive;
 use bollard::container::{Config, CreateContainerOptions, DownloadFromContainerOptions, ListContainersOptions, LogsOptions, StartContainerOptions, UploadToContainerOptions, WaitContainerOptions};
@@ -12,10 +14,12 @@ use futures_util::{AsyncRead, StreamExt, TryStreamExt};
 use hyper::body::HttpBody;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
+use tokio::select;
 use tokio_util::io::StreamReader;
 use tokio_util::compat::{TokioAsyncReadCompatExt};
 use crate::config::CONFIG;
 use crate::package::Package;
+use crate::web::broadcast::{Broadcast, BroadcastEvent};
 
 const RUNNER_IMAGE_BUILD_IN: &str = "/app/build";
 const RUNNER_IMAGE_BUILD_OUT: &str = "/app/target";
@@ -35,12 +39,14 @@ pub type ContainerId = String;
 /// this is a wrapper for docker which creates and interacts with runner containers
 pub struct Runner {
     pub docker: Docker,
+    broadcast: Arc<Broadcast>
+    // TODO: Add some kind of Broadcast struct here
 }
 
 impl Runner {
 
     /// creates a new runner by taking the docker from the default socket
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new(broadcast: Arc<Broadcast>) -> anyhow::Result<Self> {
         let docker = if let Some(url) = &CONFIG.docker_url {
 
             if url.starts_with("tcp://") || url.starts_with("http://") {
@@ -60,38 +66,66 @@ impl Runner {
         };
 
         Ok(Self {
-            docker: docker.context("failed to initialize docker")?
+            docker: docker.context("failed to initialize docker")?,
+            broadcast
         })
     }
 
     /// builds the package inside a container
-    pub async fn build(&self, container: &ContainerId) -> anyhow::Result<RunStatus> {
+    pub async fn build(&self, container: &ContainerId, package: &Package) -> anyhow::Result<RunStatus> {
         let start = Utc::now();
+        // ideally we would have a oneshot channel here but this causes problems in the loop since rx doesn't implement Copy
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
 
         // start container
         self.docker.start_container(container, None::<StartContainerOptions<String>>).await?;
 
-        // wait for container to exit and collect logs
-        let result =
-            self.docker.wait_container(container,  None::<WaitContainerOptions<String>>).collect::<Vec<_>>().await;
-
-        let end = Utc::now();
+        self.broadcast.notify(&package.base, BroadcastEvent::BuildStart).await;
 
         // retrieve logs
         let log_options = LogsOptions {
             stdout: true, stderr: true,
+            follow: true, // follow is needed since we continuously read from the stream
             since: start.timestamp(),
             ..Default::default()
         };
 
-        let logs: Vec<String> = self.docker.logs::<String>(container, Some(log_options)).filter_map(|r| async {
-            r.ok().map(|c| c.to_string())
-        }).collect::<Vec<_>>().await;
+        let mut stream = self.docker.logs::<String>(container, Some(log_options));
+        let base = package.base.clone();
+        let broadcast = self.broadcast.clone();
+        let log_collector = tokio::spawn(async move {
+            let mut logs = vec![];
+            // collect logs from stream until the abort signal is received
+            loop {
+                select! {
+                    _ = rx.recv() => break,
+                    Some(Ok(log)) = stream.next() => {
+                        let value = log.to_string();
+                        logs.push(value.clone());
+                        broadcast.notify(&base, BroadcastEvent::Log(value)).await;
+                    }
+                }
+            }
+
+            return logs.join("");
+        });
+
+
+        // wait for container to exit
+        let result =
+            self.docker.wait_container(container,  None::<WaitContainerOptions<String>>).collect::<Vec<_>>().await;
+
+        let end = Utc::now();
+        
+        // notify log collector thread to stop and return the logs
+        tx.send(()).await.context("channel to logs thread is closed")?;
+        let logs = log_collector.await.unwrap_or_default();
+
+        self.broadcast.notify(&package.base, BroadcastEvent::BuildFinish).await;
 
         Ok(RunStatus {
             success: result.first().and_then(|r| r.as_ref().ok()).is_some(),
-            logs: logs.join(""),
-
+            logs,
             started: start,
             ended: end,
         })

--- a/server/src/runner/mod.rs
+++ b/server/src/runner/mod.rs
@@ -40,7 +40,6 @@ pub type ContainerId = String;
 pub struct Runner {
     pub docker: Docker,
     broadcast: Arc<Broadcast>
-    // TODO: Add some kind of Broadcast struct here
 }
 
 impl Runner {

--- a/server/src/runner/mod.rs
+++ b/server/src/runner/mod.rs
@@ -14,12 +14,11 @@ use futures_util::{AsyncRead, StreamExt, TryStreamExt};
 use hyper::body::HttpBody;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
-use tokio::select;
 use tokio_util::io::StreamReader;
 use tokio_util::compat::{TokioAsyncReadCompatExt};
 use crate::config::CONFIG;
 use crate::package::Package;
-use crate::web::broadcast::{Broadcast, BroadcastEvent};
+use crate::web::broadcast::{Broadcast, Event};
 
 const RUNNER_IMAGE_BUILD_IN: &str = "/app/build";
 const RUNNER_IMAGE_BUILD_OUT: &str = "/app/target";
@@ -73,13 +72,11 @@ impl Runner {
     /// builds the package inside a container
     pub async fn build(&self, container: &ContainerId, package: &Package) -> anyhow::Result<RunStatus> {
         let start = Utc::now();
-        // ideally we would have a oneshot channel here but this causes problems in the loop since rx doesn't implement Copy
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
 
         // start container
         self.docker.start_container(container, None::<StartContainerOptions<String>>).await?;
 
-        self.broadcast.notify(&package.base, BroadcastEvent::BuildStart).await;
+        self.broadcast.notify(&package.base, Event::BuildStart).await;
 
         // retrieve logs
         let log_options = LogsOptions {
@@ -94,19 +91,15 @@ impl Runner {
         let broadcast = self.broadcast.clone();
         let log_collector = tokio::spawn(async move {
             let mut logs = vec![];
-            // collect logs from stream until the abort signal is received
-            loop {
-                select! {
-                    _ = rx.recv() => break,
-                    Some(Ok(log)) = stream.next() => {
-                        let value = log.to_string();
-                        logs.push(value.clone());
-                        broadcast.notify(&base, BroadcastEvent::Log(value)).await;
-                    }
+            // collect logs from stream until the container exits (and the log stream closes)
+            while let Some(next) = stream.next().await {
+                if let Ok(log) = next {
+                    let value = log.to_string();
+                    logs.push(value.clone());
+                    broadcast.notify(&base, Event::Log(value)).await;
                 }
             }
-
-            return logs.join("");
+            logs.join("")
         });
 
 
@@ -116,11 +109,10 @@ impl Runner {
 
         let end = Utc::now();
         
-        // notify log collector thread to stop and return the logs
-        tx.send(()).await.context("channel to logs thread is closed")?;
+        // get logs from log collector thread
         let logs = log_collector.await.unwrap_or_default();
 
-        self.broadcast.notify(&package.base, BroadcastEvent::BuildFinish).await;
+        self.broadcast.notify(&package.base, Event::BuildFinish).await;
 
         Ok(RunStatus {
             success: result.first().and_then(|r| r.as_ref().ok()).is_some(),

--- a/server/src/web/auth.rs
+++ b/server/src/web/auth.rs
@@ -1,10 +1,11 @@
-use std::error::Error;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use actix_web::{FromRequest, HttpRequest};
 use actix_web::dev::Payload;
 use actix_web::error::{ErrorForbidden, ErrorInternalServerError, ErrorUnauthorized};
 use actix_web::http::header::AUTHORIZATION;
+use actix_web::web::Query;
 use serene_data::secret;
 use crate::config::CONFIG;
 
@@ -16,10 +17,12 @@ impl FromRequest for AuthWrite {
     type Error = actix_web::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let params = Query::<HashMap<String, String>>::from_query(req.query_string()).expect("Should accept any query params");
+        // either read secret from `Authorization` header or from `auth` url query parameter
         let secret = match req.headers().get(AUTHORIZATION) {
             Some(value) => Ok(value.to_str().unwrap_or("").to_string()),
             None => Err(ErrorUnauthorized("no secret provided"))
-        };
+        }.or(params.into_inner().get("auth").ok_or(ErrorUnauthorized("no secret provided")).cloned());
 
         Box::pin(async move {
             let secret = secret?;

--- a/server/src/web/broadcast.rs
+++ b/server/src/web/broadcast.rs
@@ -4,21 +4,14 @@ use std::time::Duration;
 use chrono::Utc;
 use futures::future::join_all;
 use log::debug;
-use sqlx::{Pool, Sqlite};
+use serene_data::package::BroadcastEvent;
 use tokio::sync::Mutex;
 use actix_web_lab::sse;
 use actix_web_lab::sse::Sse;
 use actix_web_lab::util::InfallibleStream;
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::build::BuildSummary;
-
-const BUILD_START_EVENT: &str = "build_start";
-const BUILD_END_EVENT: &str = "build_end";
-const LOG_EVENT: &str = "log";
-const PING_EVENT: &str = "ping"; 
-
-pub enum BroadcastEvent {
+pub enum Event {
     BuildStart,
     BuildFinish,
     Log(String)
@@ -28,15 +21,13 @@ pub struct Broadcast {
     subscriptions: Mutex<HashMap<String, Vec<tokio::sync::mpsc::Sender<sse::Event>>>>,
     // cache contains build logs for packages which are currently building
     cache: Mutex<HashMap<String, Vec<String>>>,
-    db: Pool<Sqlite>
 }
 
 impl Broadcast {
-    pub fn new(db: Pool<Sqlite>) -> Arc<Self> {
+    pub fn new() -> Arc<Self> {
         let broadcast = Arc::new(Self { 
             subscriptions: Mutex::new(HashMap::new()),
             cache: Mutex::new(HashMap::new()),
-            db
         });
         Broadcast::spawn_ping(broadcast.clone());
         broadcast
@@ -61,17 +52,17 @@ impl Broadcast {
             subscriptions.iter().map(|(package, receivers)| async {
                 let receivers = join_all(
                     receivers.iter().map(|recv| async {
-                        let event = sse::Event::Data(sse::Data::new(Utc::now().timestamp_millis().to_string()).event(PING_EVENT));
+                        let event = sse::Event::Data(sse::Data::new(Utc::now().timestamp_millis().to_string()).event(BroadcastEvent::Ping.to_string()));
                         recv.send(event).await.ok().map(|_| recv.clone())
                     })
-                ).await.into_iter().filter_map(|r| r).collect::<Vec<_>>();
-                if receivers.len() > 0 {
+                ).await.into_iter().flatten().collect::<Vec<_>>();
+                if !receivers.is_empty() {
                     Some((package.clone(), receivers))
                 } else {
                     None
                 }
             })
-        ).await.into_iter().filter_map(|e| e).collect::<HashMap<_, _>>();
+        ).await.into_iter().flatten().collect::<HashMap<_, _>>();
     }
 
     /// subscribe to all package events
@@ -86,26 +77,16 @@ impl Broadcast {
 
         let cache = self.cache.lock().await;
         // should there be logs in the cache then there is currently a build running and we want to return those logs
-        // otherwise we return the latest logs from the database
         if let Some(logs) = cache.get(&pkg) {
-            let event = sse::Event::Data(sse::Data::new(logs.join("")).event(LOG_EVENT));
+            let event = sse::Event::Data(sse::Data::new(logs.join("")).event(BroadcastEvent::Log.to_string()));
             tx.send(event).await.ok();
-        } else {
-            if let Some(summary) = BuildSummary::find_latest_for_package(&pkg, &self.db).await.ok().unwrap_or_default() {
-                if let Some(logs) = summary.logs {
-                    let event = sse::Event::Data(sse::Data::new(logs.logs).event(LOG_EVENT));
-                    tx.send(event).await.ok();
-                    let event = sse::Event::Data(sse::Data::new(String::new()).event(BUILD_END_EVENT));
-                    tx.send(event).await.ok();
-                }
-            }
         }
 
         Ok(Sse::from_infallible_receiver(rx))
     }
 
     /// notify all subscriptions for a specific package with an event
-    pub async fn notify(&self, package: &String, event: BroadcastEvent) {
+    pub async fn notify(&self, package: &str, event: Event) {
         let pkg = package.to_lowercase();
         let subscriptions = self.subscriptions.lock().await;
         let receivers = subscriptions.get(&pkg).cloned().unwrap_or_default();
@@ -113,19 +94,19 @@ impl Broadcast {
 
         let mut cache = self.cache.lock().await;
         let event = match event {
-            BroadcastEvent::BuildStart => {
+            Event::BuildStart => {
                 cache.insert(pkg, vec![]);
-                sse::Event::Data(sse::Data::new(String::new()).event(BUILD_START_EVENT))
+                sse::Event::Data(sse::Data::new(String::new()).event(BroadcastEvent::BuildStart.to_string()))
             },
-            BroadcastEvent::BuildFinish => {
+            Event::BuildFinish => {
                 cache.remove(&pkg);
-                sse::Event::Data(sse::Data::new(String::new()).event(BUILD_END_EVENT))
+                sse::Event::Data(sse::Data::new(String::new()).event(BroadcastEvent::BuildEnd.to_string()))
             },
-            BroadcastEvent::Log(log) => {
+            Event::Log(log) => {
                 if let Some(logs) = cache.get_mut(&pkg) {
                     logs.push(log.clone())
                 }
-                sse::Event::Data(sse::Data::new(log).event(LOG_EVENT))
+                sse::Event::Data(sse::Data::new(log).event(BroadcastEvent::Log.to_string()))
             },
         };
 

--- a/server/src/web/broadcast.rs
+++ b/server/src/web/broadcast.rs
@@ -1,0 +1,137 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use chrono::Utc;
+use futures::future::join_all;
+use log::debug;
+use sqlx::{Pool, Sqlite};
+use tokio::sync::Mutex;
+use actix_web_lab::sse;
+use actix_web_lab::sse::Sse;
+use actix_web_lab::util::InfallibleStream;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::build::BuildSummary;
+
+const BUILD_START_EVENT: &str = "build_start";
+const BUILD_END_EVENT: &str = "build_end";
+const LOG_EVENT: &str = "log";
+const PING_EVENT: &str = "ping"; 
+
+pub enum BroadcastEvent {
+    BuildStart,
+    BuildFinish,
+    Log(String)
+}
+
+pub struct Broadcast {
+    subscriptions: Mutex<HashMap<String, Vec<tokio::sync::mpsc::Sender<sse::Event>>>>,
+    // cache contains build logs for packages which are currently building
+    cache: Mutex<HashMap<String, Vec<String>>>,
+    db: Pool<Sqlite>
+}
+
+impl Broadcast {
+    pub fn new(db: Pool<Sqlite>) -> Arc<Self> {
+        let broadcast = Arc::new(Self { 
+            subscriptions: Mutex::new(HashMap::new()),
+            cache: Mutex::new(HashMap::new()),
+            db
+        });
+        Broadcast::spawn_ping(broadcast.clone());
+        broadcast
+    }
+
+    fn spawn_ping(this: Arc<Self>) {
+        tokio::task::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(10));
+
+            loop {
+                interval.tick().await;
+                this.remove_stale_connections().await;
+            }
+        });
+    }
+
+    /// remove all connections for which the ping broadcast fails to avoid unnecessary broadcasts
+    async fn remove_stale_connections(&self) {
+        let mut subscriptions = self.subscriptions.lock().await;
+
+        *subscriptions = join_all(
+            subscriptions.iter().map(|(package, receivers)| async {
+                let receivers = join_all(
+                    receivers.iter().map(|recv| async {
+                        let event = sse::Event::Data(sse::Data::new(Utc::now().timestamp_millis().to_string()).event(PING_EVENT));
+                        recv.send(event).await.ok().map(|_| recv.clone())
+                    })
+                ).await.into_iter().filter_map(|r| r).collect::<Vec<_>>();
+                if receivers.len() > 0 {
+                    Some((package.clone(), receivers))
+                } else {
+                    None
+                }
+            })
+        ).await.into_iter().filter_map(|e| e).collect::<HashMap<_, _>>();
+    }
+
+    /// subscribe to all package events
+    pub async fn subscribe(&self, package: String) -> actix_web::Result<Sse<InfallibleStream<ReceiverStream<sse::Event>>>> {
+        let pkg = package.to_lowercase();
+        let (tx, rx) = tokio::sync::mpsc::channel::<sse::Event>(10);
+        let mut subscriptions = self.subscriptions.lock().await;
+        let mut receivers = subscriptions.get(&pkg).cloned().unwrap_or_default();
+        debug!("added new receiver for package {pkg}");
+        receivers.push(tx.clone());
+        subscriptions.insert(pkg.clone(), receivers);
+
+        let cache = self.cache.lock().await;
+        // should there be logs in the cache then there is currently a build running and we want to return those logs
+        // otherwise we return the latest logs from the database
+        if let Some(logs) = cache.get(&pkg) {
+            let event = sse::Event::Data(sse::Data::new(logs.join("")).event(LOG_EVENT));
+            tx.send(event).await.ok();
+        } else {
+            if let Some(summary) = BuildSummary::find_latest_for_package(&pkg, &self.db).await.ok().unwrap_or_default() {
+                if let Some(logs) = summary.logs {
+                    let event = sse::Event::Data(sse::Data::new(logs.logs).event(LOG_EVENT));
+                    tx.send(event).await.ok();
+                    let event = sse::Event::Data(sse::Data::new(String::new()).event(BUILD_END_EVENT));
+                    tx.send(event).await.ok();
+                }
+            }
+        }
+
+        Ok(Sse::from_infallible_receiver(rx))
+    }
+
+    /// notify all subscriptions for a specific package with an event
+    pub async fn notify(&self, package: &String, event: BroadcastEvent) {
+        let pkg = package.to_lowercase();
+        let subscriptions = self.subscriptions.lock().await;
+        let receivers = subscriptions.get(&pkg).cloned().unwrap_or_default();
+        debug!("notifying package {pkg} with {} receivers", receivers.len());
+
+        let mut cache = self.cache.lock().await;
+        let event = match event {
+            BroadcastEvent::BuildStart => {
+                cache.insert(pkg, vec![]);
+                sse::Event::Data(sse::Data::new(String::new()).event(BUILD_START_EVENT))
+            },
+            BroadcastEvent::BuildFinish => {
+                cache.remove(&pkg);
+                sse::Event::Data(sse::Data::new(String::new()).event(BUILD_END_EVENT))
+            },
+            BroadcastEvent::Log(log) => {
+                if let Some(logs) = cache.get_mut(&pkg) {
+                    logs.push(log.clone())
+                }
+                sse::Event::Data(sse::Data::new(log).event(LOG_EVENT))
+            },
+        };
+
+        for receiver in receivers {
+            // we can ignore errors since the stale client gets removed in next cleanup anyways
+            receiver.send(event.clone()).await.ok();
+        }
+    }
+}


### PR DESCRIPTION
This adds the functionality to subscribe to build logs live. To the `serene info <package> logs` command the `--subscribe` and `--attach` arguments were added. 
When supplied without `--attach`, the `--subscribe` argument prints the latest build log or continuously prints the active build log should the package be currently built. When supplied with `--attach` the same is printed but additionally, the cli waits for new builds and prints them as they come.

All events are transmitted through server sent events using the `actix-web-lab` crate. The functionality is implemented in the `Broadcast` struct. 