### PR TITLE
Add package signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,16 +44,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d223b13fd481fc0d1f83bb12659ae774d9e3601814c68a0bc539731698cca743"
+checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.4.1",
  "brotli",
  "bytes",
@@ -93,13 +93,15 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
+ "cfg-if",
  "http 0.2.11",
  "regex",
+ "regex-lite",
  "serde",
  "tracing",
 ]
@@ -154,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.5.1"
+version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a6556ddebb638c2358714d853257ed226ece6023ef9364f23f0c70737ea984"
+checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -183,6 +185,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -194,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
  "proc-macro2",
@@ -394,6 +397,15 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "async-channel"
@@ -640,6 +652,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.4.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -732,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -748,6 +795,18 @@ checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "buffered-reader"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd098763fdb64579407a8c83cf0d751e6d4a7e161d0114c89cc181a2ca760ec8"
+dependencies = [
+ "bzip2",
+ "flate2",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -778,6 +837,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +865,15 @@ checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
  "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -806,6 +895,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -938,9 +1038,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -1038,6 +1138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1221,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1263,6 +1399,12 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1451,8 +1593,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1494,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1911,6 +2055,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -1952,6 +2105,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,16 +2150,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2075,6 +2284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memsec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797b9d6bb23aab2fc369c65f871be49214f5c759af65bde26ffaaa2b646b492"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2331,39 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "nettle"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e6ff4a94e5d34a1fd5abbd39418074646e2fa51b257198701330f22fcd6936"
+dependencies = [
+ "getrandom",
+ "libc",
+ "nettle-sys",
+ "thiserror",
+ "typenum",
+]
+
+[[package]]
+name = "nettle-sys"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b495053a10a19a80e3a26bf1212e92e29350797b5f5bdc58268c3f3f818e66ec"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "pkg-config",
+ "tempfile",
+ "vcpkg",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -2263,6 +2511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2530,25 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.1.0",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2390,6 +2663,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2747,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2779,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -2706,6 +3002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +3159,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
+name = "sequoia-openpgp"
+version = "1.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b870b0275eeae174058fcf0ce5affccaaafeb7eceeabce8d6c7f51fbe6a41e2a"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "buffered-reader",
+ "bzip2",
+ "chrono",
+ "dyn-clone",
+ "flate2",
+ "getrandom",
+ "idna",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "libc",
+ "memsec",
+ "nettle",
+ "once_cell",
+ "regex",
+ "regex-syntax",
+ "sha1collisiondetection",
+ "thiserror",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,6 +3316,7 @@ dependencies = [
  "lazy_static",
  "log",
  "raur",
+ "sequoia-openpgp",
  "serde",
  "serde_json",
  "serene-data",
@@ -3047,6 +3379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1collisiondetection"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f606421e4a6012877e893c399822a4ed4b089164c5969424e1b9d1e66e6964b"
+dependencies = [
+ "digest",
+ "generic-array",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3398,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3075,6 +3423,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -3381,6 +3735,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd10a070fb1f2796a288abec42695db4682a82b6f12ffacd60fb8d5ad3a4a12"
 
 [[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,6 +3867,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3954,15 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3831,6 +4218,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unicode_categories"
@@ -4257,6 +4650,12 @@ checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "yaml-rust"

--- a/TODO.md
+++ b/TODO.md
@@ -31,10 +31,11 @@ adjusted for v0.3.0 on 23.02.24
 - [X] Pull runner image automatically on startup and periodically
 - [ ] Rebuild cleaned when non-clean containers fail
 - [X] Add itself as a source to build container, so we have rudimentary aur dependency support
+- [ ] Import server public key through cli
 
 #### Must haves
 - [X] Store state in a database and not a json file
-- [ ] Signing packages
+- [x] Signing packages
 - [X] Local / Custom source, where a user can upload a custom pkgbuild
 
 #### Features

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,7 +32,7 @@ async-tar = "0.4.2"
 hyper = "0.14.27"
 
 # web
-actix-web = "4.4.0"
+actix-web = "4.8.0"
 actix-files = "0.6.2"
 actix-web-lab = "0.20.2"
 
@@ -52,3 +52,6 @@ anyhow = "1.0.75"
 
 # config
 lazy_static = "1.4.0"
+
+# crypto
+sequoia-openpgp = { version = "1.21.1" }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -76,7 +76,7 @@ impl Config {
 
             architecture: env::var("ARCH").unwrap_or(default.architecture),
             repository_name: env::var("NAME").unwrap_or(default.repository_name),
-            sign_key_password: env::var("SIGN_KEY_PASSWORD").ok(),
+            sign_key_password: env::var("SIGN_KEY_PASSWORD").ok().or(default.sign_key_password),
             own_repository_url: env::var("OWN_REPOSITORY_URL").ok().or(default.own_repository_url),
 
             schedule_image: env::var("SCHEUDLE_IMAGE").unwrap_or(default.schedule_image),

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub architecture: String,
     /// the name of the exposed repository
     pub repository_name: String,
+    /// password for private key used for signatures
+    pub sign_key_password: Option<String>,
     /// default scheduling of packages
     pub schedule_default: String,
     /// scheduling of development packages
@@ -45,6 +47,7 @@ impl Default for Config {
 
             architecture: env::consts::ARCH.to_string(),
             repository_name: "serene".to_string(),
+            sign_key_password: None,
 
             schedule_default: "0 0 0 * * *".to_string(), // 00:00 UTC every day
             schedule_devel: "0 0 0 * * *".to_string(),
@@ -73,6 +76,7 @@ impl Config {
 
             architecture: env::var("ARCH").unwrap_or(default.architecture),
             repository_name: env::var("NAME").unwrap_or(default.repository_name),
+            sign_key_password: env::var("SIGN_KEY_PASSWORD").ok(),
             own_repository_url: env::var("OWN_REPOSITORY_URL").ok().or(default.own_repository_url),
 
             schedule_image: env::var("SCHEUDLE_IMAGE").unwrap_or(default.schedule_image),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
 
     let schedule = Arc::new(RwLock::new(schedule));
 
-    info!("serene started successfully!");
+    info!("serene started successfully on port {}!", CONFIG.port);
     // web app
     HttpServer::new(move ||
         App::new()
@@ -99,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
             .service(web::subscribe_logs)
             .service(web::settings)
             .service(web::pkgbuild)
+            .service(web::get_signature_public_key)
     ).bind(("0.0.0.0", CONFIG.port))?.run().await?;
 
     Ok(())

--- a/server/src/repository/crypto.rs
+++ b/server/src/repository/crypto.rs
@@ -19,7 +19,7 @@ fn get_keypair() -> anyhow::Result<KeyPair> {
     let policy = StandardPolicy::new();
 
     let key = cert.keys()
-        .unencrypted_secret()
+        .secret()
         .with_policy(&policy, None)
         .supported()
         .alive()
@@ -30,7 +30,7 @@ fn get_keypair() -> anyhow::Result<KeyPair> {
 
     let mut key = key.key().clone();
     if key.secret().is_encrypted() {
-        let password = Password::from(CONFIG.sign_key_password.clone().unwrap_or_default());
+        let password = Password::from(CONFIG.sign_key_password.clone().context("private key is encrypted but no password was provided")?);
         let algo = key.pk_algo();
         key.secret_mut()
             .decrypt_in_place(algo, &password)

--- a/server/src/repository/crypto.rs
+++ b/server/src/repository/crypto.rs
@@ -6,7 +6,7 @@ use sequoia_openpgp::crypto::{KeyPair, Password};
 use sequoia_openpgp::parse::Parse;
 use sequoia_openpgp::policy::StandardPolicy;
 use sequoia_openpgp::serialize::{Serialize};
-use sequoia_openpgp::serialize::stream::{Armorer, Message, Signer};
+use sequoia_openpgp::serialize::stream::{Message, Signer};
 use crate::config::CONFIG;
 use crate::repository::PRIV_KEY_FILE;
 
@@ -44,10 +44,6 @@ pub fn sign(output: &Path, file: &Path) -> anyhow::Result<()> {
     let keypair = get_keypair()?;
     let mut sink = fs::File::create(output).context("failed to create signature sink")?;
     let message = Message::new(&mut sink);
-    let message = Armorer::new(message)
-        .kind(sequoia_openpgp::armor::Kind::Signature)
-        .build()
-        .context("failed to build signature armorer")?;
 
     let mut message = Signer::new(message, keypair).detached().build().context("failed to create signer")?;
     let mut source = fs::File::open(file).context("failed to open source file")?;

--- a/server/src/repository/crypto.rs
+++ b/server/src/repository/crypto.rs
@@ -64,7 +64,7 @@ pub fn get_public_key_bytes<W: io::Write + Send + Sync>(output: &mut W) -> anyho
     let mut writer = sequoia_openpgp::armor::Writer::new(output, sequoia_openpgp::armor::Kind::PublicKey)
         .context("failed to build public key armorer")?;
 
-    cert.as_tsk().serialize(&mut writer).context("failed to export public key")?;
+    cert.serialize(&mut writer).context("failed to export public key")?;
     writer.finalize()?;
     Ok(())
 }

--- a/server/src/repository/crypto.rs
+++ b/server/src/repository/crypto.rs
@@ -1,0 +1,70 @@
+use std::{fs, io};
+use std::path::Path;
+use anyhow::{Context};
+use sequoia_openpgp::Cert;
+use sequoia_openpgp::crypto::{KeyPair, Password};
+use sequoia_openpgp::parse::Parse;
+use sequoia_openpgp::policy::StandardPolicy;
+use sequoia_openpgp::serialize::{Serialize};
+use sequoia_openpgp::serialize::stream::{Armorer, Message, Signer};
+use crate::config::CONFIG;
+use crate::repository::PRIV_KEY_FILE;
+
+pub fn should_sign_packages() -> bool {
+    Path::new(PRIV_KEY_FILE).exists()
+}
+
+fn get_keypair() -> anyhow::Result<KeyPair> {
+    let cert = Cert::from_file(PRIV_KEY_FILE).context("failed to read private key file")?;
+    let policy = StandardPolicy::new();
+
+    let key = cert.keys()
+        .unencrypted_secret()
+        .with_policy(&policy, None)
+        .supported()
+        .alive()
+        .revoked(false)
+        .for_signing()
+        .next()
+        .context("certificate should contain at least one key")?;
+
+    let mut key = key.key().clone();
+    if key.secret().is_encrypted() {
+        let password = Password::from(CONFIG.sign_key_password.clone().unwrap_or_default());
+        let algo = key.pk_algo();
+        key.secret_mut()
+            .decrypt_in_place(algo, &password)
+            .context("failed to unlock private key")?;
+    };
+
+    key.into_keypair().context("failed to create keypair")
+}
+
+pub fn sign(output: &Path, file: &Path) -> anyhow::Result<()> {
+    let keypair = get_keypair()?;
+    let mut sink = fs::File::create(output).context("failed to create signature sink")?;
+    let message = Message::new(&mut sink);
+    let message = Armorer::new(message)
+        .kind(sequoia_openpgp::armor::Kind::Signature)
+        .build()
+        .context("failed to build signature armorer")?;
+
+    let mut message = Signer::new(message, keypair).detached().build().context("failed to create signer")?;
+    let mut source = fs::File::open(file).context("failed to open source file")?;
+    io::copy(&mut source, &mut message).context("failed to sign file")?;
+
+    message.finalize().context("failed to write signature file")?;
+    Ok(())
+}
+
+pub fn get_public_key_bytes<W: io::Write + Send + Sync>(output: &mut W) -> anyhow::Result<()> {
+    let cert = Cert::from_file(PRIV_KEY_FILE).context("failed to read private key file")?;
+    // this behaviour is not very well documented from the sequoia side. The code to serialize public keys can be found in the code for the `sq` cli here:
+    // https://gitlab.com/sequoia-pgp/sequoia-sq/-/blame/main/src/commands/key/export.rs?ref_type=heads#L103
+    let mut writer = sequoia_openpgp::armor::Writer::new(output, sequoia_openpgp::armor::Kind::PublicKey)
+        .context("failed to build public key armorer")?;
+
+    cert.as_tsk().serialize(&mut writer).context("failed to export public key")?;
+    writer.finalize()?;
+    Ok(())
+}

--- a/server/src/repository/manage.rs
+++ b/server/src/repository/manage.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
-use std::process::{Stdio};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use tokio::process::Command;
+use crate::repository::crypto;
 
 fn db_file(name: &str) -> String {
     format!("{name}.db.tar.gz")
@@ -9,6 +9,10 @@ fn db_file(name: &str) -> String {
 
 pub async fn add(name: &str, packages: &Vec<String>, dir: &Path) -> anyhow::Result<()> {
     let mut command = Command::new("repo-add");
+    
+    if crypto::should_sign_packages() {
+        command.args(["--verify", "--sign"]);
+    }
 
     command.arg(db_file(name));
     for package in packages {
@@ -33,4 +37,13 @@ pub async fn remove(name: &str, packages: &Vec<String>, dir: &Path) -> anyhow::R
 
     if output.status.success() { Ok(()) }
     else { Err(anyhow!("failed to use repo-remove: {}", String::from_utf8_lossy(&output.stderr))) }
+}
+
+pub async fn sign(files: &Vec<String>, base_path: &Path) -> anyhow::Result<()> {
+    for file in files {
+        let path = base_path.join(file);
+        let signature_path = base_path.join(format!("{file}.sig"));
+        crypto::sign(&signature_path, &path).context(format!("failed to create signature for file: {file}"))?;
+    }
+    Ok(())
 }

--- a/server/src/repository/manage.rs
+++ b/server/src/repository/manage.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::os::unix;
+use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context};
 use tokio::process::Command;
 use crate::repository::crypto;
@@ -7,21 +8,50 @@ fn db_file(name: &str) -> String {
     format!("{name}.db.tar.gz")
 }
 
+fn old_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!("{}.old", path.file_name().unwrap_or_default().to_str().unwrap_or_default()))
+}
+
+fn sig_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!("{}.sig", path.file_name().unwrap_or_default().to_str().unwrap_or_default()))
+}
+
+fn sign_repository(name: &str, dir: &Path) -> anyhow::Result<()> {
+    let db_path = &dir.join(format!("{name}.db"));
+    let db_archive_path = &dir.join(db_file(name));
+    let files_path = &dir.join(format!("{name}.files"));
+    let files_archive_path = &dir.join(format!("{name}.files.tar.gz"));
+
+    if old_path(db_archive_path).exists() {
+        crypto::sign(&sig_path(&old_path(db_archive_path)), &old_path(db_archive_path)).context("failed to sign old repository database")?;
+    }
+    if old_path(files_archive_path).exists() {
+        crypto::sign(&sig_path(&old_path(files_archive_path)), &old_path(files_archive_path)).context("failed to sign old repository files")?;
+    }
+
+    crypto::sign(&sig_path(db_archive_path), db_archive_path).context("failed to sign repository database")?;
+    if !sig_path(db_path).exists() {
+        unix::fs::symlink(&sig_path(db_archive_path), &sig_path(db_path)).context("failed to link repository database signature")?;
+    }
+    crypto::sign(&sig_path(files_archive_path), files_archive_path).context("failed to sign repository files")?;
+    if !sig_path(files_path).exists() {
+        unix::fs::symlink(&sig_path(files_archive_path), &sig_path(files_path)).context("failed to link repository database signature")?;
+    }
+
+    Ok(())
+}
+
 pub async fn add(name: &str, packages: &Vec<String>, dir: &Path) -> anyhow::Result<()> {
     let mut command = Command::new("repo-add");
 
     command.arg(db_file(name));
-    for package in packages {
-        command.arg(package);
-    }
+    command.args(packages);
 
     let output = command.current_dir(dir).output().await?;
 
     if output.status.success() { 
         if crypto::should_sign_packages() {
-            let signed_db_path = dir.join(format!("{}.sig", db_file(name)));
-            let db_path = dir.join(db_file(name));
-            crypto::sign(&signed_db_path, &db_path).context("failed to sign repository database")?;
+            sign_repository(name, dir)?;
         }
         Ok(())
     }
@@ -32,21 +62,23 @@ pub async fn remove(name: &str, packages: &Vec<String>, dir: &Path) -> anyhow::R
     let mut command = Command::new("repo-remove");
 
     command.arg(db_file(name));
-    for package in packages {
-        command.arg(package);
-    }
+    command.args(packages);
 
     let output = command.current_dir(dir).output().await?;
 
-    if output.status.success() { Ok(()) }
+    if output.status.success() {
+        if crypto::should_sign_packages() {
+            sign_repository(name, dir)?;
+        }
+        Ok(())
+    }
     else { Err(anyhow!("failed to use repo-remove: {}", String::from_utf8_lossy(&output.stderr))) }
 }
 
 pub async fn sign(files: &Vec<String>, base_path: &Path) -> anyhow::Result<()> {
     for file in files {
-        let path = base_path.join(file);
-        let signature_path = base_path.join(format!("{file}.sig"));
-        crypto::sign(&signature_path, &path).context(format!("failed to create signature for file: {file}"))?;
+        let path = &base_path.join(file);
+        crypto::sign(&sig_path(path), path).context(format!("failed to create signature for file: {file}"))?;
     }
     Ok(())
 }

--- a/server/src/repository/manage.rs
+++ b/server/src/repository/manage.rs
@@ -8,10 +8,6 @@ fn db_file(name: &str) -> String {
     format!("{name}.db.tar.gz")
 }
 
-fn old_path(path: &Path) -> PathBuf {
-    path.with_file_name(format!("{}.old", path.file_name().unwrap_or_default().to_str().unwrap_or_default()))
-}
-
 fn sig_path(path: &Path) -> PathBuf {
     path.with_file_name(format!("{}.sig", path.file_name().unwrap_or_default().to_str().unwrap_or_default()))
 }
@@ -22,20 +18,13 @@ fn sign_repository(name: &str, dir: &Path) -> anyhow::Result<()> {
     let files_path = &dir.join(format!("{name}.files"));
     let files_archive_path = &dir.join(format!("{name}.files.tar.gz"));
 
-    if old_path(db_archive_path).exists() {
-        crypto::sign(&sig_path(&old_path(db_archive_path)), &old_path(db_archive_path)).context("failed to sign old repository database")?;
-    }
-    if old_path(files_archive_path).exists() {
-        crypto::sign(&sig_path(&old_path(files_archive_path)), &old_path(files_archive_path)).context("failed to sign old repository files")?;
-    }
-
     crypto::sign(&sig_path(db_archive_path), db_archive_path).context("failed to sign repository database")?;
     if !sig_path(db_path).exists() {
-        unix::fs::symlink(&sig_path(db_archive_path), &sig_path(db_path)).context("failed to link repository database signature")?;
+        unix::fs::symlink(sig_path(db_archive_path), sig_path(db_path)).context("failed to link repository database signature")?;
     }
     crypto::sign(&sig_path(files_archive_path), files_archive_path).context("failed to sign repository files")?;
     if !sig_path(files_path).exists() {
-        unix::fs::symlink(&sig_path(files_archive_path), &sig_path(files_path)).context("failed to link repository database signature")?;
+        unix::fs::symlink(sig_path(files_archive_path), sig_path(files_path)).context("failed to link repository database signature")?;
     }
 
     Ok(())

--- a/server/src/repository/mod.rs
+++ b/server/src/repository/mod.rs
@@ -13,9 +13,11 @@ use crate::config::CONFIG;
 use crate::package::Package;
 
 mod manage;
+pub mod crypto;
 
 const REPO_DIR: &str = "repository";
 const REPO_SERENE: &str = "bases.json";
+const PRIV_KEY_FILE: &str = "sign-private-key.sec.asc";
 
 /// returns the webservice which exposes the repository
 pub fn webservice() -> Files {
@@ -103,6 +105,12 @@ impl PackageRepository {
         archive::extract_files(&mut output, &files, Path::new(REPO_DIR)).await
             .context("failed to extract all packages from build container")?;
 
+        // sign packages if enabled
+        if crypto::should_sign_packages() {
+            manage::sign(&files, Path::new(REPO_DIR)).await
+                .context("failed to sign packages")?;
+        }
+
         // add package files
         manage::add(&self.name, &files, Path::new(REPO_DIR)).await
             .context("failed to add files to repository")?;
@@ -126,10 +134,16 @@ impl PackageRepository {
             manage::remove(&self.name, &entries.iter().map(|e| e.name.clone()).collect(), Path::new(REPO_DIR)).await
                 .context("failed to remove files from repository")?;
 
-            // delete package files
+            // delete package (and signature) files
             for entry in entries {
                 fs::remove_file(Path::new(REPO_DIR).join(&entry.file)).await
-                    .context(format!("failed to delete file from repository: {}", entry.file))?
+                    .context(format!("failed to delete file from repository: {}", entry.file))?;
+
+                let sign_path = Path::new(REPO_DIR).join(format!("{}.sig", entry.file));
+                if sign_path.exists() {
+                    fs::remove_file(sign_path).await
+                        .context(format!("failed to delete signature file from repository: {}.sig", entry.file))?;
+                }
             }
         } else {
             return Err(anyhow!("could not find package {} in repository", &package.base))

--- a/server/src/repository/mod.rs
+++ b/server/src/repository/mod.rs
@@ -17,7 +17,7 @@ pub mod crypto;
 
 const REPO_DIR: &str = "repository";
 const REPO_SERENE: &str = "bases.json";
-const PRIV_KEY_FILE: &str = "sign-private-key.sec.asc";
+const PRIV_KEY_FILE: &str = "sign_key.asc";
 
 /// returns the webservice which exposes the repository
 pub fn webservice() -> Files {


### PR DESCRIPTION
Added support for package signing. 

By mounting a gpg private key into the serene container the package signing can be enabled. When enabled, it creates for every package built a `.sig` file containing a detached gpg signature. 

The public key which can be imported into pacman to verify the built packages can be downloaded from the `/key` api endpoint