### PR TITLE
Add webhook functionality

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -75,6 +75,13 @@ serene info my-package set prepare "echo 'i am run before the makepkg'"
 serene info my-package set flags "nocheck" "holdver"
 ```
 
+**Manage the server**: To manage some server properties, you can use the manage subcommand:
+
+```shell
+# Request and print the webhook secret for the package `my-package`
+serene manage webhook my-package
+```
+
 **Print the local secret of the CLI:** To print the local secret again, run the following:
 ```shell
 # Prints the secret to add to the `authorized_secrets` file.

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -34,14 +34,14 @@ pub fn run(config: &Config, action: Action) {
         }
         Action::Info { name, what, all } => {
             match what {
-                None => { 
-                    info(config, &name, all); 
+                None => {
+                    info(config, &name, all);
                 }
-                Some(InfoCommand::Pkgbuild) => { 
-                    pkgbuild(config, &name); 
+                Some(InfoCommand::Pkgbuild) => {
+                    pkgbuild(config, &name);
                 }
-                Some(InfoCommand::Build { id }) => { 
-                    build_info(config, &name, &id); 
+                Some(InfoCommand::Build { id }) => {
+                    build_info(config, &name, &id);
                 }
                 Some(InfoCommand::Logs { id, subscribe, linger }) => {
                     if id.is_some() {
@@ -50,15 +50,15 @@ pub fn run(config: &Config, action: Action) {
                         subscribe_build_logs(config, &name, linger, subscribe);
                     }
                 }
-                Some(InfoCommand::Set { property }) => { 
-                    set_setting(config, &name, property) 
+                Some(InfoCommand::Set { property }) => {
+                    set_setting(config, &name, property)
                 }
             }
         }
         Action::Manage { manage } => {
             match manage {
-                ManageSubcommand::Webhook { name } => {
-                    webhook_secret(config, &name);
+                ManageSubcommand::Webhook { name, machine } => {
+                    webhook_secret(config, &name, machine);
                 }
             }
         }

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -3,8 +3,8 @@ pub mod pacman;
 
 use clap_complete::Shell;
 use colored::Colorize;
-use crate::action::procedures::{add, build, build_info, build_logs, info, list, pkgbuild, remove, set_setting, subscribe_build_logs};
-use crate::command::{Action, InfoCommand};
+use crate::action::procedures::{add, build, build_info, build_logs, info, list, pkgbuild, remove, set_setting, subscribe_build_logs, webhook_secret};
+use crate::command::{Action, InfoCommand, ManageSubcommand};
 use crate::complete::generate_completions;
 use crate::config::Config;
 use crate::log::Log;
@@ -52,6 +52,13 @@ pub fn run(config: &Config, action: Action) {
                 }
                 Some(InfoCommand::Set { property }) => { 
                     set_setting(config, &name, property) 
+                }
+            }
+        }
+        Action::Manage { manage } => {
+            match manage {
+                ManageSubcommand::Webhook { name } => {
+                    webhook_secret(config, &name);
                 }
             }
         }

--- a/cli/src/action/procedures.rs
+++ b/cli/src/action/procedures.rs
@@ -105,21 +105,21 @@ fn wait_and_install(c: &Config, base: &str, quiet: bool) {
 /// add a package to the repository
 pub fn add(c: &Config, what: &str, replace: bool, file: bool, custom: bool, pkgbuild: bool, devel: bool, install: bool, quiet: bool) {
     let mut log = Log::start("initializing package adding");
-    
-    // read file if requested 
+
+    // read file if requested
     let what = if file {
         log.next("loading content from file");
-        
+
         let mut file = match File::open(what) {
             Ok(f) => { f }
             Err(e) => { log.fail(&format!("failed to open file: {e:#}")); return }
         };
-        
+
         let mut buf = String::new();
         if let Err(e) = file.read_to_string(&mut buf) {
             log.fail(&format!("failed to read file: {e:#}")); return
         }
-        
+
         buf
     } else { what.to_owned() };
 
@@ -356,15 +356,19 @@ pub fn build_logs(c: &Config, package: &str, build: &Option<String>) {
 }
 
 /// print the personalized webhook secret for a package
-pub fn webhook_secret(c: &Config, package: &str) {
+pub fn webhook_secret(c: &Config, package: &str, machine: bool) {
     let log = Log::start("requesting webhook secret");
 
     match get_webhook_secret(c, package) {
         Ok(secret) => {
             log.succeed("received webhook secret successfully");
-            println!("Your personalized webhook secret for the package {} is:\n{secret}\n", package.italic());
-            println!("To trigger the webhook you have to send a HTTP-{} request to:", "POST".bold());
-            println!("{}/webhook/package/{package}/build?secret={secret}", c.url)
+            if machine {
+                println!("{secret}")
+            } else {
+                println!("Your personalized webhook secret for the package {} is:\n{secret}\n", package.italic());
+                println!("To trigger the webhook you have to send a HTTP-{} request to:", "POST".bold());
+                println!("{}/webhook/package/{package}/build?secret={secret}", c.url)
+            }
         }
         Err(e) => { log.fail(&e.msg()) }
     }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -25,12 +25,12 @@ pub enum Action {
         /// <WHAT> is a custom repository
         #[clap(short, long, group = "nonaur", help_heading = "Custom Sources")]
         custom: bool,
-        
-        /// <WHAT> is a custom pkgbuild 
+
+        /// <WHAT> is a custom pkgbuild
         #[clap(short, long, group = "nonaur", help_heading = "Custom Sources")]
         pkgbuild: bool,
 
-        /// add as a development package 
+        /// add as a development package
         #[clap(short, long, requires = "nonaur", help_heading = "Custom Sources")]
         devel: bool,
 
@@ -101,7 +101,7 @@ pub enum Action {
         #[clap(subcommand)]
         manage: ManageSubcommand
     },
-    
+
     #[command(hide = true)]
     Completions
 }
@@ -144,7 +144,11 @@ pub enum ManageSubcommand {
     /// get a personalized webhook secret for a package
     Webhook {
         /// name of the package
-        name: String
+        name: String,
+
+        /// print the secret in a machine readable way
+        #[clap(short, long)]
+        machine: bool
     }
 }
 
@@ -179,6 +183,6 @@ pub enum SettingsSubcommand {
     /// set additional makepkg flags
     Flags {
         /// flags to add, without the dashes
-        flags: Vec<String> 
+        flags: Vec<String>
     },
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -95,6 +95,12 @@ pub enum Action {
         #[clap(short, long)]
         machine: bool
     },
+
+    /// manage things related to the server
+    Manage {
+        #[clap(subcommand)]
+        manage: ManageSubcommand
+    },
     
     #[command(hide = true)]
     Completions
@@ -130,6 +136,15 @@ pub enum InfoCommand {
         /// property to set
         #[clap(subcommand)]
         property: SettingsSubcommand
+    }
+}
+
+#[derive(Subcommand)]
+pub enum ManageSubcommand {
+    /// get a personalized webhook secret for a package
+    Webhook {
+        /// name of the package
+        name: String
     }
 }
 

--- a/cli/src/web/requests.rs
+++ b/cli/src/web/requests.rs
@@ -42,6 +42,11 @@ pub fn get_build_logs(c: &Config, package: &str, id: &str) -> Result<String> {
     get::<String>(c, &format!("package/{package}/build/{id}/logs"))
 }
 
+/// get the secret for the webhook of a given package
+pub fn get_webhook_secret(c: &Config, package: &str) -> Result<String> {
+    get::<String>(c, &format!("webhook/package/{package}/secret"))
+}
+
 /// get info about a specific package
 pub fn get_package(c: &Config, package: &str) -> Result<PackageInfo> {
     get::<PackageInfo>(c, &format!("package/{package}"))

--- a/server/README.md
+++ b/server/README.md
@@ -4,13 +4,13 @@ The server is the main part of serene, as it actually builds and manages the pac
 The server is distributed in the form of a docker container. This file documents the direct usage, building and configuration of it.
 
 ## Repository
-The server will expose a package repository over http. It is located at `/[arch]` so most probably on `/x86_64` and does not require authentication. 
+The server will expose a package repository over http. It is located at `/[arch]` so most probably on `/x86_64` and does not require authentication.
 
 The repository follows the format of an ordinary Arch Linux repository, just the way pacman expects it. The name of the actual repository (determined by the .db file) can be [configured](#configuration) on the container, and is `serene` by default. The package archive format is `.tar.zst`.
 
 ### Package Signing
 For security reasons the packages built by the build server can be signed. Whilst the signature is no guarantee the built package does not contain any malware it still verifies the package was built on your build server.
-This is useful when you host your repository without a ssl certificate (which is generally discouraged) or when there are mirrors which redistribute packages from your build server. 
+This is useful when you host your repository without a ssl certificate (which is generally discouraged) or when there are mirrors which redistribute packages from your build server.
 
 To enable package signing you'll have to mount a gpg private key into the server container. While testing the package signing we found **RSA keys** have to have a minimum length of **2048 bits** to work with the library used for signing.
 
@@ -23,7 +23,7 @@ gpg --armor --output private-key.asc --export-secret-key <key-id>
 >[!IMPORTANT]
 > It's highly recommended to use a new gpg key for the package signing which isn't used anywhere else. Putting a private key and it's password onto a publicly accessible server poses a risk for identity theft!
 
-Now, when [deploying](#deployment) you'll have to add an additional volume bind to the `docker-compose.yml`: 
+Now, when [deploying](#deployment) you'll have to add an additional volume bind to the `docker-compose.yml`:
 ```yml
 # docker-compose.yml
 
@@ -33,7 +33,7 @@ services:
     volumes:
       - /path/to/private-key.asc:/app/sign_key.asc
       # ... other volumes
-      
+
 ```
 If the signing is enabled after the initial setup of the server only new package builds will be signed. Old packages need to be rebuilt in order to get signed.
 
@@ -41,7 +41,7 @@ Should your private key be protected by a password you'll have to additionally [
 
 To enable package verification using pacman you'll need to download the public key from the `/key` api endpoint and [import it into your pacman keys](https://wiki.archlinux.org/title/Pacman/Package_signing#Adding_unofficial_keys).
 
-Since the packages are now signed you can remove the `SigLevel = Optional TrustAll` from the [repository definition](../README.md#installing-only-the-repository) in the `pacman.conf`. 
+Since the packages are now signed you can remove the `SigLevel = Optional TrustAll` from the [repository definition](../README.md#installing-only-the-repository) in the `pacman.conf`.
 By removing this configuration pacman will fall back to the `SigLevel` defined at the `[options]` level which by default only allows signed packages to be downloaded from a repository.
 More about the `SigLevel` configuration can be read in the [arch wiki](https://wiki.archlinux.org/title/Pacman/Package_signing#Configuring_pacman).
 
@@ -64,13 +64,13 @@ The endpoints of the API will be documented in the future. In the meantime, have
 ### Webhooks
 
 The server allows for webhook functionality to trigger builds for packages using a http request. Webhooks require authentication using a special secret. Those secrets are bound to the
-authorized secret of a user and a package name. This allows a single webhook secret to only trigger webhooks for one single package. Webhooks are disabled by default, to enable them you need to set the `WEBHOOK_SECRET` [config option](#configuration). 
+authorized secret of a user and a package name. This allows a single webhook secret to only trigger webhooks for one single package. Webhooks are disabled by default, to enable them you need to set the `WEBHOOK_SECRET` [config option](#configuration).
 
 For every user with an authorized secret it's possible to request a webhook token for a specific package using the [CLI](../cli/README.md#usage) or the `/webhook/package/{name}/secret` endpoint where the authorized secret is passed through the `Authorization` header.
-The returned secret can be used in the `/webhook/package/{name}/build?secret=<webhook-secret>` HTTP-POST request to trigger a build for the specified package. 
+The returned secret can be used in the `/webhook/package/{name}/build?secret=<webhook-secret>` HTTP-POST request to trigger a build for the specified package.
 
 The webhook secrets are stateless and bound to an authorized secret of a user. This means every webhook secret is valid as long as the secret of the user is still part of the `authorized_secrets` file. As soon as the user secret is removed from
-the server the webhook secret is invalidated as well. 
+the server the webhook secret is invalidated as well.
 
 ## Container
 The container is as lightweight as possible and thus alpine-based. Any configuration is done through environment variables on the container.
@@ -83,7 +83,7 @@ It also stores many things on the filesystem, which may or may not be of interes
 - `/app/serene.db`: This is the *sqlite* database where all the builds, logs, etc. are stored about the different packages.
 - `/app/sources`: This is a directory structure that stores the `PKGBUILD`s which are copied to containers for building.
 - `/app/repository`: This is the repository containing the build packages. It is served as is for pacman to access.
-- `/app/sign_key.asc`: This **file** contains the private key used for package signing if provided 
+- `/app/sign_key.asc`: This **file** contains the private key used for package signing if provided
 
 ### Deployment
 It is recommended to deploy the container via docker compose. Here is an example for a basic deployment:

--- a/server/data/src/secret.rs
+++ b/server/data/src/secret.rs
@@ -1,5 +1,5 @@
 use base64::Engine;
-use base64::prelude::BASE64_STANDARD;
+use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE};
 use sha2::{Digest, Sha256};
 
 /// hashes a secret and converts it to string, the way it is in authorized_secrets
@@ -8,4 +8,13 @@ pub fn hash(secret: &str) -> String {
     hasher.update(secret);
 
     BASE64_STANDARD.encode(hasher.finalize())
+}
+
+/// hash a secret and convert it to a string which is url safe <br />
+/// this is especially needed for webhook secrets which are delivered in a query parameter
+pub fn hash_url_safe(secret: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret);
+    
+    BASE64_URL_SAFE.encode(hasher.finalize())
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -38,6 +38,8 @@ pub struct Config {
     pub build_cli: bool,
     /// url for runners to reach the server to pull dependencies from its repo
     pub own_repository_url: Option<String>,
+    /// secret used to sign webhook tokens
+    pub webhook_secret: Option<String>,
 }
 
 impl Default for Config {
@@ -55,12 +57,14 @@ impl Default for Config {
 
             container_prefix: "serene-aur-runner-".to_string(),
             runner_image: "ghcr.io/virtcode/serene-aur-runner:main".to_string(),
-            
+
             docker_url: None,
 
             port: 80,
             build_cli: true,
-            own_repository_url: None
+            own_repository_url: None,
+
+            webhook_secret: None
         }
     }
 }
@@ -85,7 +89,7 @@ impl Config {
 
             container_prefix: env::var("RUNNER_PREFIX").unwrap_or(default.container_prefix),
             runner_image: env::var("RUNNER_IMAGE").unwrap_or(default.runner_image),
-            
+
             docker_url: env::var("DOCKER_URL").ok().or(default.docker_url),
 
             port: env::var("PORT").ok()
@@ -93,7 +97,9 @@ impl Config {
                 .unwrap_or(default.port),
             build_cli: env::var("BUILD_CLI").ok()
                 .and_then(|s| bool::from_str(&s).map_err(|_| warn!("failed to parse BUILD_CLI, using default")).ok())
-                .unwrap_or(default.build_cli)
+                .unwrap_or(default.build_cli),
+
+            webhook_secret: env::var("WEBHOOK_SECRET").ok().or(default.webhook_secret)
         }
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -27,10 +27,10 @@ async fn main() -> anyhow::Result<()> {
 
     // initializing database
     let db = database::connect().await?;
-    
+
     // initialize broadcast
     let broadcast = Broadcast::new();
-    
+
     // initializing runner
     let runner = Arc::new(RwLock::new(
         Runner::new(broadcast.clone())
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     // creating scheduler
     let mut schedule = BuildScheduler::new(builder.clone()).await
         .context("failed to start package scheduler")?;
-    
+
     // creating image scheduler
     let image_scheduler = ImageScheduler::new(runner.clone()).await
         .context("failed to start image scheduler")?;
@@ -99,6 +99,8 @@ async fn main() -> anyhow::Result<()> {
             .service(web::subscribe_logs)
             .service(web::settings)
             .service(web::pkgbuild)
+            .service(web::get_webhook_secret)
+            .service(web::build_webhook)
             .service(web::get_signature_public_key)
     ).bind(("0.0.0.0", CONFIG.port))?.run().await?;
 

--- a/server/src/web/auth.rs
+++ b/server/src/web/auth.rs
@@ -1,21 +1,24 @@
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use actix_web::{FromRequest, HttpRequest};
 use actix_web::dev::Payload;
-use actix_web::error::{ErrorForbidden, ErrorInternalServerError, ErrorUnauthorized};
+use actix_web::error::{ErrorBadRequest, ErrorForbidden, ErrorInternalServerError, ErrorServiceUnavailable, ErrorUnauthorized};
 use actix_web::http::header::AUTHORIZATION;
+use actix_web::web::Query;
+use futures::FutureExt;
 use serene_data::secret;
 use crate::config::CONFIG;
 
 const AUTHORIZED_PATH: &str = "authorized_secrets";
 
 /// this extractor makes sure that users are authorized when making special requests
-pub struct AuthWrite;
+pub struct AuthWrite(String);
 impl FromRequest for AuthWrite {
     type Error = actix_web::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
-        
+
         let secret = match req.headers().get(AUTHORIZATION) {
             Some(value) => Ok(value.to_str().unwrap_or("").to_string()),
             None => Err(ErrorUnauthorized("no secret provided"))
@@ -23,13 +26,17 @@ impl FromRequest for AuthWrite {
 
         Box::pin(async move {
             let secret = secret?;
-            if secret_authorized(&secret).await? { Ok(Self) }
+            if secret_authorized(&secret).await? { Ok(Self(secret)) }
             else { Err(ErrorForbidden("invalid secret")) }
         })
     }
 }
 
-pub struct AuthRead;
+impl AuthWrite {
+    pub fn get_secret(&self) -> &String { &self.0 }
+}
+
+pub struct AuthRead(Option<String>);
 impl FromRequest for AuthRead {
     type Error = actix_web::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
@@ -37,7 +44,7 @@ impl FromRequest for AuthRead {
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
         if CONFIG.allow_reads {
             // always allow
-            Box::pin(async { Ok(Self) })
+            Box::pin(async { Ok(Self(None)) })
         }
         else {
             let req = req.clone();
@@ -46,21 +53,68 @@ impl FromRequest for AuthRead {
                 let mut payload = Payload::None;
 
                 // delegate processing to write auth
-                AuthWrite::from_request(&req.clone(), &mut payload).await.map(|_| Self)
+                AuthWrite::from_request(&req.clone(), &mut payload).await.map(|a| Self(Some(a.0)))
             })
         }
     }
 }
 
-/// checks whether a given secret is authorized
-async fn secret_authorized(secret: &str) -> Result<bool, actix_web::Error> {
+impl AuthRead {
+    pub fn get_secret(&self) -> &Option<String> { &self.0 }
+}
+
+pub struct AuthWebhook(String);
+impl FromRequest for AuthWebhook {
+    type Error = actix_web::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
+
+    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
+        let params = Query::<HashMap<String, String>>::from_query(req.query_string()).expect("Should accept any query params");
+        let webhook_secret = params.into_inner().get("secret").ok_or(ErrorUnauthorized("no webhook secret provided")).cloned();
+        let parameters: HashMap<String, String> = req.match_info().iter().map(|(k,v)| (k.to_string(), v.to_string())).collect();
+        let name = parameters.get("name").ok_or(ErrorBadRequest("no package name parameter found")).cloned();
+
+        Box::pin(async move {
+            let webhook_secret = webhook_secret?;
+            let secrets = get_secrets().await?;
+            let name = name?;
+
+            for authorized_secret in secrets.into_iter() {
+                if create_webhook_secret(&name, &authorized_secret)?.eq(&webhook_secret) {
+                    return Ok(Self(webhook_secret));
+                }
+            }
+
+            return Err(ErrorForbidden("no signing secret found"))
+        })
+    }
+}
+
+impl AuthWebhook {
+    pub fn get_secret(&self) -> &String { &self.0 }
+}
+
+/// get all authorized secrets
+async fn get_secrets() -> actix_web::Result<Vec<String>> {
     let file = tokio::fs::read_to_string(AUTHORIZED_PATH).await
         .map_err(|_e| ErrorInternalServerError("failed to read authorized secrets"))?;
 
     let secrets = file.trim()
         .split('\n')
-        .filter_map(|s| s.split_whitespace().next())
-        .collect::<Vec<&str>>();
+        .filter_map(|s| s.split_whitespace().next().map(|str| str.to_string()))
+        .collect::<Vec<String>>();
+    Ok(secrets)
+}
 
-    Ok(secrets.contains(&secret::hash(secret).as_str()))
+/// checks whether a given secret is authorized
+async fn secret_authorized(secret: &str) -> Result<bool, actix_web::Error> {
+    let secrets = get_secrets().await?;
+    Ok(secrets.contains(&secret::hash(secret)))
+}
+
+/// create a secret which can be used for webhooks for a given package
+pub fn create_webhook_secret(package: &String, authorized_secret: &String) -> actix_web::Result<String> {
+    let server_secret = CONFIG.webhook_secret.clone().ok_or(ErrorServiceUnavailable("webhooks aren't enabled on this server"))?;
+    let secret_str = format!("{authorized_secret}-{package}-{server_secret}");
+    Ok(secret::hash_url_safe(secret_str.as_str()))
 }

--- a/server/src/web/auth.rs
+++ b/server/src/web/auth.rs
@@ -85,7 +85,7 @@ impl FromRequest for AuthWebhook {
                 }
             }
 
-            return Err(ErrorForbidden("no signing secret found"))
+            Err(ErrorForbidden("no signing secret found"))
         })
     }
 }


### PR DESCRIPTION
I've added the functionality to create webhooks. At the moment it's only a single webhook to trigger builds for a specific package. 

In the general webhook concept there is a new kind of secret: the webhook secret
This secret is the hash of the new `WEBHOOK_SECRET` stored on the server, the package name for which the webhook secret can be used and the authorized secret of the user. By using this combination the webhook secrets are stateless but still bound to an user whilst still being very precise as a single webhook secret can only be used for webhooks related to a single package. 

A webhook secret for a package can be requested through the `/webhook/package/my-package/secret` HTTP-GET request which is behind `AuthWrite`. The process is also integrated into the CLI where the `serene manage webhook my-package` command can be used to retrieve the webhook secret.

As already mentioned the only webhook currently implemented is the webhook to trigger builds of packages. This webhook can be executed by sending a HTTP-POST request to `/webhook/package/my-package/build?secret=webhook-secret`

The system should allow for further webhooks if every needed. However, with the current implementation it's locked down to having only webhooks for packages (as we include the package name into the webhook secret).