### PR TITLE
Differentiate build reasons

### DIFF
--- a/cli/src/action/procedures.rs
+++ b/cli/src/action/procedures.rs
@@ -5,7 +5,8 @@ use crate::config::Config;
 use crate::log::Log;
 use crate::table::{ago, table, Column};
 use crate::web::data::{
-    describe_cron_timezone_hack, get_build_id, BuildProgressFormatter, BuildReasonFormatter, BuildStateFormatter
+    describe_cron_timezone_hack, get_build_id, BuildProgressFormatter, BuildReasonFormatter,
+    BuildStateFormatter,
 };
 use crate::web::requests::{
     add_package, build_package, get_build, get_build_logs, get_builds, get_info, get_package,

--- a/cli/src/action/procedures.rs
+++ b/cli/src/action/procedures.rs
@@ -5,7 +5,7 @@ use crate::config::Config;
 use crate::log::Log;
 use crate::table::{ago, table, Column};
 use crate::web::data::{
-    describe_cron_timezone_hack, get_build_id, BuildProgressFormatter, BuildStateFormatter,
+    describe_cron_timezone_hack, get_build_id, BuildProgressFormatter, BuildReasonFormatter, BuildStateFormatter
 };
 use crate::web::requests::{
     add_package, build_package, get_build, get_build_logs, get_builds, get_info, get_package,
@@ -362,6 +362,7 @@ pub fn info(c: &Config, package: &str, all: bool) {
         Column::new("id").force(),
         Column::new("version"),
         Column::new("state").force(),
+        Column::new("reason").force(),
         Column::new("date").force(),
         Column::new("time").force(),
     ];
@@ -373,6 +374,7 @@ pub fn info(c: &Config, package: &str, all: bool) {
                 get_build_id(peek).dimmed(),
                 peek.version.as_ref().map(|s| s.normal()).unwrap_or_else(|| "unknown".dimmed()),
                 peek.state.colored_substantive(),
+                peek.reason.colored(),
                 peek.started.with_timezone(&Local).format("%x %X").to_string().normal(),
                 peek.ended
                     .map(|ended| format!("{}s", (ended - peek.started).num_seconds()))

--- a/cli/src/action/procedures.rs
+++ b/cli/src/action/procedures.rs
@@ -423,6 +423,7 @@ pub fn build_info(c: &Config, package: &str, build: &Option<String>) {
                 _ => "".to_string(),
             };
 
+            println!("{:<8} {}", "reason:", b.reason.colored());
             println!("\n{:<8} {} {}", "status:", b.state.colored_substantive(), additive);
 
             match &b.state {

--- a/cli/src/web/data.rs
+++ b/cli/src/web/data.rs
@@ -3,7 +3,7 @@ use chrono::{Local, Offset};
 use colored::{ColoredString, Colorize};
 use cron_descriptor::cronparser::cron_expression_descriptor::get_description_cron_options;
 use cron_descriptor::cronparser::Options;
-use serene_data::build::{BuildInfo, BuildProgress, BuildState};
+use serene_data::build::{BuildInfo, BuildProgress, BuildReason, BuildState};
 use std::str::FromStr;
 
 pub trait BuildStateFormatter {
@@ -27,6 +27,22 @@ impl BuildStateFormatter for BuildState {
             BuildState::Success => "success".green(),
             BuildState::Failure => "failure".red(),
             BuildState::Fatal(_, _) => "fatal".bright_red(),
+        }
+    }
+}
+
+pub trait BuildReasonFormatter {
+    fn colored(&self) -> ColoredString;
+}
+
+impl BuildReasonFormatter for BuildReason {
+    fn colored(&self) -> ColoredString {
+        match self {
+            BuildReason::Webhook => "webhook".bright_blue(),
+            BuildReason::Manual => "manual".bright_blue(),
+            BuildReason::Schedule => "schedule".dimmed(),
+            BuildReason::Initial => "initial".bright_blue(),
+            BuildReason::Unknown => "unknown".dimmed(),
         }
     }
 }

--- a/server/data/src/build.rs
+++ b/server/data/src/build.rs
@@ -34,6 +34,9 @@ pub struct BuildInfo {
     /// state of the build
     pub state: BuildState,
 
+    /// reason why the build ran
+    pub reason: BuildReason,
+
     /// version that was built
     pub version: Option<String>,
 
@@ -41,4 +44,21 @@ pub struct BuildInfo {
     pub started: DateTime<Utc>,
     /// end time of the build
     pub ended: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Deserialize, EnumString, Display, Clone)]
+#[strum(serialize_all = "lowercase")]
+pub enum BuildReason {
+    /// build was triggered by a webhook
+    Webhook,
+    /// build was manually triggered by an user
+    Manual,
+    /// build was triggered in a schedule
+    Schedule,
+    /// initial build of package after addition
+    Initial,
+    /// build reason is not known
+    ///
+    /// only here for compatibility with older versions
+    Unknown,
 }

--- a/server/migrations/20240917122808_build_reason.sql
+++ b/server/migrations/20240917122808_build_reason.sql
@@ -1,3 +1,1 @@
--- Add migration script here
-
 ALTER TABLE build ADD COLUMN reason VARCHAR NOT NULL DEFAULT "unknown";

--- a/server/migrations/20240917122808_build_reason.sql
+++ b/server/migrations/20240917122808_build_reason.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+
+ALTER TABLE build ADD COLUMN reason VARCHAR NOT NULL DEFAULT "unknown";

--- a/server/src/build/mod.rs
+++ b/server/src/build/mod.rs
@@ -56,7 +56,13 @@ impl Builder {
 
     /// starts a build for a package, if there is no update, the build will be
     /// skipped (except when forced)
-    pub async fn run_scheduled(&self, package: &str, force: bool, clean: bool, reason: BuildReason) {
+    pub async fn run_scheduled(
+        &self,
+        package: &str,
+        force: bool,
+        clean: bool,
+        reason: BuildReason,
+    ) {
         info!("starting build for package {package} now");
 
         let package = match Package::find(package, &self.db).await {

--- a/server/src/build/schedule.rs
+++ b/server/src/build/schedule.rs
@@ -47,7 +47,12 @@ impl BuildScheduler {
     }
 
     /// runs a one-shot build for a package
-    pub async fn run(&mut self, package: &Package, clean: bool, reason: BuildReason) -> anyhow::Result<()> {
+    pub async fn run(
+        &mut self,
+        package: &Package,
+        clean: bool,
+        reason: BuildReason,
+    ) -> anyhow::Result<()> {
         info!("scheduling one-shot build for package {} now", &package.base);
 
         let lock = self.get_lock(package);
@@ -105,7 +110,9 @@ impl BuildScheduler {
             let base = base.clone();
             let builder = builder.clone();
 
-            Box::pin(async move { run(lock, builder, false, base, false, BuildReason::Schedule).await })
+            Box::pin(
+                async move { run(lock, builder, false, base, false, BuildReason::Schedule).await },
+            )
         })
         .context(format!("failed to create job for package {}", package.base))?;
 

--- a/server/src/build/schedule.rs
+++ b/server/src/build/schedule.rs
@@ -4,6 +4,7 @@ use crate::package::Package;
 use crate::runner::Runner;
 use anyhow::{anyhow, Context};
 use log::{debug, error, info, warn};
+use serene_data::build::BuildReason;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -46,7 +47,7 @@ impl BuildScheduler {
     }
 
     /// runs a one-shot build for a package
-    pub async fn run(&mut self, package: &Package, clean: bool) -> anyhow::Result<()> {
+    pub async fn run(&mut self, package: &Package, clean: bool, reason: BuildReason) -> anyhow::Result<()> {
         info!("scheduling one-shot build for package {} now", &package.base);
 
         let lock = self.get_lock(package);
@@ -63,8 +64,9 @@ impl BuildScheduler {
             let lock = lock.clone();
             let base = base.clone();
             let builder = builder.clone();
+            let reason = reason.clone();
 
-            Box::pin(async move { run(lock, builder, true, base, clean).await })
+            Box::pin(async move { run(lock, builder, true, base, clean, reason).await })
         })
         .context(format!("failed to create job for package {}", package.base))?;
 
@@ -103,7 +105,7 @@ impl BuildScheduler {
             let base = base.clone();
             let builder = builder.clone();
 
-            Box::pin(async move { run(lock, builder, false, base, false).await })
+            Box::pin(async move { run(lock, builder, false, base, false, BuildReason::Schedule).await })
         })
         .context(format!("failed to create job for package {}", package.base))?;
 
@@ -125,6 +127,7 @@ async fn run(
     force: bool,
     base: String,
     clean: bool,
+    reason: BuildReason,
 ) {
     // makes sure a package is not built twice at the same time
     if *lock.read().await {
@@ -133,7 +136,7 @@ async fn run(
     }
 
     *lock.write().await = true;
-    builder.read().await.run_scheduled(&base, force, clean).await;
+    builder.read().await.run_scheduled(&base, force, clean, reason).await;
     *lock.write().await = false;
 }
 

--- a/server/src/database/build.rs
+++ b/server/src/database/build.rs
@@ -7,7 +7,9 @@ use serene_data::build::{BuildProgress, BuildReason, BuildState};
 use sqlx::{query, query_as};
 use std::str::FromStr;
 
-/// See server/migrations/20240210164401_build.sql
+/// See migrations:
+/// server/migrations/20240210164401_build.sql
+/// server/migrations/20240917122808_build_reason.sql
 #[derive(Debug)]
 struct BuildRecord {
     package: String,

--- a/server/src/database/build.rs
+++ b/server/src/database/build.rs
@@ -3,7 +3,7 @@ use crate::database::{Database, DatabaseConversion};
 use crate::runner::RunStatus;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
-use serene_data::build::{BuildProgress, BuildState};
+use serene_data::build::{BuildReason, BuildProgress, BuildState};
 use sqlx::{query, query_as};
 use std::str::FromStr;
 
@@ -16,6 +16,7 @@ struct BuildRecord {
     started: NaiveDateTime,
     ended: Option<NaiveDateTime>,
 
+    reason: String,
     state: String,
     progress: Option<String>,
     fatal: Option<String>,
@@ -45,6 +46,7 @@ impl DatabaseConversion<BuildRecord> for BuildSummary {
             state,
             progress,
             fatal,
+            reason: self.reason.to_string(),
             version: self.version.clone(),
             run_success: self.logs.as_ref().map(|s| s.success),
             run_logs: self.logs.as_ref().map(|s| s.logs.clone()),
@@ -72,6 +74,7 @@ impl DatabaseConversion<BuildRecord> for BuildSummary {
 
         Ok(BuildSummary {
             package: other.package,
+            reason: BuildReason::from_str(&other.reason).unwrap_or(BuildReason::Unknown),
             state,
             version: other.version,
             started: other.started.and_utc(),
@@ -154,10 +157,10 @@ impl BuildSummary {
         let record = self.create_record()?;
 
         query!(r#"
-            INSERT INTO build (package, started, ended, state, progress, fatal, version, run_success, run_logs, run_started, run_ended)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            INSERT INTO build (package, started, ended, state, progress, fatal, version, run_success, run_logs, run_started, run_ended, reason)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
         "#,
-            record.package, record.started, record.ended, record.state, record.progress, record.fatal, record.version, record.run_success, record.run_logs, record.run_started, record.run_ended
+            record.package, record.started, record.ended, record.state, record.progress, record.fatal, record.version, record.run_success, record.run_logs, record.run_started, record.run_ended, record.reason
         )
             .execute(db).await?;
 

--- a/server/src/database/build.rs
+++ b/server/src/database/build.rs
@@ -3,7 +3,7 @@ use crate::database::{Database, DatabaseConversion};
 use crate::runner::RunStatus;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
-use serene_data::build::{BuildReason, BuildProgress, BuildState};
+use serene_data::build::{BuildProgress, BuildReason, BuildState};
 use sqlx::{query, query_as};
 use std::str::FromStr;
 

--- a/server/src/package/mod.rs
+++ b/server/src/package/mod.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
 use hyper::Body;
 use log::info;
+use serene_data::build::BuildReason;
 use serene_data::package::MakepkgFlag;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -124,7 +125,7 @@ pub async fn try_add_cli(db: &Database, scheduler: &mut BuildScheduler) -> anyho
         package.change_settings(db).await?;
 
         scheduler.schedule(&package).await?;
-        scheduler.run(&package, true).await?;
+        scheduler.run(&package, true, BuildReason::Initial).await?;
 
         info!("successfully added serene-cli");
     }

--- a/server/src/web/data.rs
+++ b/server/src/web/data.rs
@@ -39,6 +39,7 @@ impl BuildSummary {
             state: self.state.clone(),
             started: self.started,
             ended: self.ended,
+            reason: self.reason.clone(),
         }
     }
 }

--- a/server/src/web/mod.rs
+++ b/server/src/web/mod.rs
@@ -188,7 +188,12 @@ pub async fn build(
         .internal()?
         .ok_or_else(|| ErrorNotFound(format!("package with base {} is not added", &package)))?;
 
-    scheduler.write().await.run(&package, body.into_inner().clean, BuildReason::Manual).await.internal()?;
+    scheduler
+        .write()
+        .await
+        .run(&package, body.into_inner().clean, BuildReason::Manual)
+        .await
+        .internal()?;
 
     Ok(empty_response())
 }

--- a/server/src/web/mod.rs
+++ b/server/src/web/mod.rs
@@ -18,6 +18,7 @@ use auth::{create_webhook_secret, AuthWebhook};
 use chrono::DateTime;
 use hyper::StatusCode;
 use serde::Deserialize;
+use serene_data::build::BuildReason;
 use serene_data::package::{
     PackageAddRequest, PackageAddSource, PackageBuildRequest, PackageSettingsRequest,
 };
@@ -101,7 +102,7 @@ pub async fn add(
         // scheduling package
         let mut scheduler = scheduler.write().await;
         scheduler.schedule(&package).await.internal()?;
-        scheduler.run(&package, true).await.internal()?;
+        scheduler.run(&package, true, BuildReason::Initial).await.internal()?;
     }
 
     Ok(Json(package.to_info()))
@@ -187,7 +188,7 @@ pub async fn build(
         .internal()?
         .ok_or_else(|| ErrorNotFound(format!("package with base {} is not added", &package)))?;
 
-    scheduler.write().await.run(&package, body.into_inner().clean).await.internal()?;
+    scheduler.write().await.run(&package, body.into_inner().clean, BuildReason::Manual).await.internal()?;
 
     Ok(empty_response())
 }
@@ -364,7 +365,7 @@ pub async fn build_webhook(
         .internal()?
         .ok_or_else(|| ErrorNotFound(format!("package with base {} is not added", &package)))?;
 
-    scheduler.write().await.run(&package, false).await.internal()?;
+    scheduler.write().await.run(&package, false, BuildReason::Webhook).await.internal()?;
 
     Ok(empty_response())
 }


### PR DESCRIPTION
This pull request resolves the #10 issue 

There are five different build reasons:
* initial: The initial build when the package is added to the repository
* schedule: The build was triggered by a cron schedule
* manual: The build was triggered manually through the api
* webhook: The build was triggered by a webhook
* unknown: The reason for the build is not known (this is for compatibility with versions which hadn't the `reason` field in the database)

The build reason is displayed in the `info <name>` command for a specific package