### PR TITLE
feat: gpg-agent support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "capnp"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5e468996c73ea6d3d2bffc2b738782487f878286615b7f76e11af15a9ada3f"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "capnp-futures"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f3ee810b3890498e51028448ac732cdd5009223897124dd2fac6b085b5d867"
+dependencies = [
+ "capnp",
+ "futures",
+]
+
+[[package]]
+name = "capnp-rpc"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe57ab22a5e121e6fddaf36e837514aab9ae888bcff2baa6fda5630820dfc501"
+dependencies = [
+ "capnp",
+ "capnp-futures",
+ "futures",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1278,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1262,6 +1323,12 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -1441,6 +1508,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2158,9 +2235,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -2475,6 +2552,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking"
@@ -3160,6 +3243,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
+name = "sequoia-gpg-agent"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4db5fdd92efb296d42b194e2114f21ba737d5d2905b5e8063a8207eb953685"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "futures",
+ "lalrpop",
+ "lalrpop-util",
+ "libc",
+ "sequoia-ipc",
+ "sequoia-openpgp",
+ "stfu8",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "sequoia-ipc"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89aecb8a95233361c172546b037e0ea4c63b0dacbaeb52a25bcf1dddf78a3ee3"
+dependencies = [
+ "anyhow",
+ "buffered-reader",
+ "capnp-rpc",
+ "ctor",
+ "dirs",
+ "fs2",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "libc",
+ "memsec",
+ "rand",
+ "sequoia-openpgp",
+ "socket2 0.5.5",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "winapi",
+]
+
+[[package]]
 name = "sequoia-openpgp"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,6 +3447,7 @@ dependencies = [
  "lazy_static",
  "log",
  "raur",
+ "sequoia-gpg-agent",
  "sequoia-openpgp",
  "serde",
  "serde_json",
@@ -3724,6 +3855,12 @@ name = "srcinfo"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceaee0d48949e3aa5365945de3e467e797b30b4f8636c2e580121a293fd77519"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
 name = "strfmt"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -56,3 +56,4 @@ lazy_static = "1.4.0"
 
 # crypto
 sequoia-openpgp = { version = "1.21.1" }
+sequoia-gpg-agent = { version = "0.4.2" }

--- a/server/README.md
+++ b/server/README.md
@@ -12,18 +12,21 @@ The repository follows the format of an ordinary Arch Linux repository, just the
 For security reasons the packages built by the build server can be signed. Whilst the signature is no guarantee the built package does not contain any malware it still verifies the package was built on your build server.
 This is useful when you host your repository without a ssl certificate (which is generally discouraged) or when there are mirrors which redistribute packages from your build server.
 
-To enable package signing you'll have to mount a gpg private key into the server container. While testing the package signing we found **RSA keys** have to have a minimum length of **2048 bits** to work with the library used for signing.
+To enable package signing you'll have to provide the server container with a private key. A suitable key must have a minimum length of 2048 bits. There are two methods to provide a private key to your server, either via keyfile, or via a running [gpg-agent](https://www.gnupg.org/(en)/documentation/manuals/gnupg24/gpg-agent.1.html).
 
-The gpg private key can be exported like this:
+>[!IMPORTANT]
+> It's highly recommended to use a new gpg key for the package signing which isn't used anywhere else. Putting a private key and it's password onto a publicly accessible server poses a risk for identity theft!
+
+Also note that if the signing is enabled after the initial setup of the server only new package builds will be signed. Old packages need to be rebuilt in order to get signed.
+
+#### Using a Keyfile
+The easiest way to configure signing is by providing the container with a private keyfile. When not using any hardware devices to provide the secret key, this is the recommended setup. A gpg private key can be exported like this:
 ```shell
 # export private key into `private-key.asc` in armored ascii format
 gpg --armor --output private-key.asc --export-secret-key <key-id>
 ```
 
->[!IMPORTANT]
-> It's highly recommended to use a new gpg key for the package signing which isn't used anywhere else. Putting a private key and it's password onto a publicly accessible server poses a risk for identity theft!
-
-Now, when [deploying](#deployment) you'll have to add an additional volume bind to the `docker-compose.yml`:
+Now, when [deploying](#deployment) you'll have to add another bind mount to the `docker-compose.yml`:
 ```yml
 # docker-compose.yml
 
@@ -33,11 +36,81 @@ services:
     volumes:
       - /path/to/private-key.asc:/app/sign_key.asc
       # ... other volumes
-
+    environment:
+      # if your key requires a password, add the following to your envs
+      - SIGN_KEY_PASSWORD: <key-password>
+      # ... remaining config
 ```
-If the signing is enabled after the initial setup of the server only new package builds will be signed. Old packages need to be rebuilt in order to get signed.
 
-Should your private key be protected by a password you'll have to additionally [configure the password](#configuration).
+#### Using `gpg-agent`
+If you want to store your private key in a more secure way, for example in a hardware device, you can use the `gpg-agent` as your keystore and let the server find the key from there.
+
+To use this, you'll need to have a `gpg-agent` running and accessible to the server. The agent will then be exposed to the server inside the container via a bind mount to its socket. It is recommended to start your gpg-agent via your init system or something similar.
+
+<details>
+<summary><b>Managing the agent with systemd</b></summary>
+
+Create a systemd socket and service for your gpg-agent:
+```ini
+# /etc/systemd/system/serene-gpg-agent.socket
+
+[Unit]
+Description=GnuPG cryptographic agent and passphrase cache for serene
+
+[Socket]
+ListenStream=/etc/serene/gnupg/S.gpg-agent
+FileDescriptorName=std
+SocketMode=0600
+DirectoryMode=0700
+
+[Install]
+RequiredBy=docker.service
+```
+```ini
+# /etc/systemd/system/serene-gpg-agent.service
+
+[Unit]
+Description=GnuPG cryptographic agent and passphrase cache for serene
+Requires=serene-gpg-agent.socket
+
+[Service]
+ExecStart=/usr/bin/gpg-agent --homedir /etc/serene/gnupg --supervised
+ExecReload=/usr/bin/gpgconf --homedir /etc/serene/gnupg --reload gpg-agent
+```
+
+Enable the service and test whether your devices are accessible:
+```bash
+# enable the socket
+sudo systemctl enable serene-gpg-agent.socket
+
+# test if your hardware key is detected
+sudo GNUPGHOME=/etc/serene/gnupg gpg-connect-agent "LEARN --sendinfo" /bye
+```
+</details>
+
+The serene server needs to know which secret key to use from the agent. For that, you'll need to provide the server with the public key for the key you want to use. The server will then search for the corresponding private key.
+
+>[!WARNING]
+> If your key is password/pin protected, but you specify the wrong password, the server might make many failed attempts to unlock your key. Be wary of this if your hardware device automatically destroys the key after too many failed attempts.
+
+Now, when [deploying](#deployment) you'll have to mount the socket and public key in the `docker-compose.yml`. We assume the `gpg-agent` socket is in `/etc/serene/gnupg/S.gpg-agent`:
+```yml
+# docker-compose.yml
+
+services:
+  serene:
+    # ... remaining service definition
+    volumes:
+      - /path/to/public-key.asc:/app/sign_key.asc
+      - /etc/serene/gnupg/S.gpg-agent:/app/S.gpg-agent
+      # ... other volumes
+    environment:
+      # if your key requires a password, add the following to your envs
+      - SIGN_KEY_PASSWORD: <key-password>
+      # ... remaining config
+```
+
+#### Using the signatures in Pacman
 
 To enable package verification using pacman you'll need to download the public key from the `/key` api endpoint and [import it into your pacman keys](https://wiki.archlinux.org/title/Pacman/Package_signing#Adding_unofficial_keys).
 

--- a/server/src/repository/crypto.rs
+++ b/server/src/repository/crypto.rs
@@ -1,6 +1,7 @@
 use crate::config::CONFIG;
 use crate::repository::{GPG_AGENT_SOCKET, KEY_FILE};
 use anyhow::Context;
+use log::warn;
 use sequoia_gpg_agent::keyinfo::KeyProtection;
 use sequoia_gpg_agent::sequoia_ipc::Keygrip;
 use sequoia_gpg_agent::{self as gpg_agent, Agent, PinentryMode};
@@ -58,7 +59,10 @@ async fn get_agent_keypair() -> anyhow::Result<gpg_agent::KeyPair> {
         .context("Failed to connect to gpg-agent")?
         .suppress_pinentry();
 
-    agent.card_info().await.context("Failed to update card info")?;
+    if let Err(e) = agent.card_info().await {
+        warn!("Failed to get card info: {e}");
+    }
+
     let keys = agent.list_keys().await.context("Failed to list keys")?;
 
     let (key, agent_key) = cert

--- a/server/src/repository/crypto.rs
+++ b/server/src/repository/crypto.rs
@@ -1,21 +1,24 @@
 use crate::config::CONFIG;
-use crate::repository::PRIV_KEY_FILE;
+use crate::repository::{GPG_AGENT_SOCKET, KEY_FILE};
 use anyhow::Context;
-use sequoia_openpgp::crypto::{KeyPair, Password};
+use sequoia_gpg_agent::keyinfo::KeyProtection;
+use sequoia_gpg_agent::sequoia_ipc::Keygrip;
+use sequoia_gpg_agent::{self as gpg_agent, Agent, PinentryMode};
+use sequoia_openpgp::crypto::{self, Password, Signer};
 use sequoia_openpgp::parse::Parse;
 use sequoia_openpgp::policy::StandardPolicy;
-use sequoia_openpgp::serialize::stream::{Message, Signer};
+use sequoia_openpgp::serialize::stream::{self, Message};
 use sequoia_openpgp::serialize::Serialize;
 use sequoia_openpgp::Cert;
 use std::path::Path;
 use std::{fs, io};
 
 pub fn should_sign_packages() -> bool {
-    Path::new(PRIV_KEY_FILE).exists()
+    Path::new(KEY_FILE).exists()
 }
 
-fn get_keypair() -> anyhow::Result<KeyPair> {
-    let cert = Cert::from_file(PRIV_KEY_FILE).context("failed to read private key file")?;
+fn get_local_keypair() -> anyhow::Result<crypto::KeyPair> {
+    let cert = Cert::from_file(KEY_FILE).context("failed to read private key file")?;
     let policy = StandardPolicy::new();
 
     let key = cert
@@ -46,13 +49,76 @@ fn get_keypair() -> anyhow::Result<KeyPair> {
     key.into_keypair().context("failed to create keypair")
 }
 
-pub fn sign(output: &Path, file: &Path) -> anyhow::Result<()> {
-    let keypair = get_keypair()?;
+async fn get_agent_keypair() -> anyhow::Result<gpg_agent::KeyPair> {
+    let cert = Cert::from_file(KEY_FILE).context("Failed to read public key file")?;
+    let policy = StandardPolicy::new();
+
+    let mut agent = Agent::connect_to_agent(GPG_AGENT_SOCKET)
+        .await
+        .context("Failed to connect to gpg-agent")?
+        .suppress_pinentry();
+
+    agent.card_info().await.context("Failed to update card info")?;
+    let keys = agent.list_keys().await.context("Failed to list keys")?;
+
+    let (key, agent_key) = cert
+        .keys()
+        .with_policy(&policy, None)
+        .supported()
+        .alive()
+        .revoked(false)
+        .for_signing()
+        .map(|k| k.key())
+        .find_map(|k| {
+            if let Ok(keygrip) = Keygrip::of(k.mpis()) {
+                return keys
+                    .iter()
+                    // we can't use keys that require user confirmation
+                    .filter(|key| !key.confirmation_required() && !key.key_disabled())
+                    .find(|key| key.keygrip() == &keygrip)
+                    .map(|key| (k, key));
+            }
+            None
+        })
+        .context("No suitable key found in gpg-agent")?;
+
+    let keypair = agent.keypair(&key).context("Failed to create keypair")?;
+
+    match &CONFIG.sign_key_password {
+        Some(password) => {
+            let password = Password::from(password.clone());
+            let keypair = keypair.set_pinentry_mode(PinentryMode::Loopback).with_password(password);
+
+            Ok(keypair)
+        }
+        None => match agent_key.protection() {
+            KeyProtection::NotProtected => Ok(keypair),
+            KeyProtection::Protected => {
+                Err(anyhow::anyhow!("private key is protected but no password was provided"))
+            }
+            KeyProtection::UnknownProtection => Ok(keypair), // will likely fail but try anyway
+            _ => Err(anyhow::anyhow!("unsupported key protection")),
+        },
+    }
+}
+
+async fn get_keypair() -> anyhow::Result<Box<dyn Signer + Send + Sync>> {
+    if Path::new(GPG_AGENT_SOCKET).exists() {
+        Ok(Box::new(get_agent_keypair().await?))
+    } else {
+        Ok(Box::new(get_local_keypair()?))
+    }
+}
+
+pub async fn sign(output: &Path, file: &Path) -> anyhow::Result<()> {
+    let keypair = get_keypair().await.context("failed to get keypair")?;
     let mut sink = fs::File::create(output).context("failed to create signature sink")?;
     let message = Message::new(&mut sink);
 
-    let mut message =
-        Signer::new(message, keypair).detached().build().context("failed to create signer")?;
+    let mut message = stream::Signer::new(message, keypair)
+        .detached()
+        .build()
+        .context("failed to create signer")?;
     let mut source = fs::File::open(file).context("failed to open source file")?;
     io::copy(&mut source, &mut message).context("failed to sign file")?;
 
@@ -61,8 +127,8 @@ pub fn sign(output: &Path, file: &Path) -> anyhow::Result<()> {
 }
 
 pub fn get_public_key_bytes<W: io::Write + Send + Sync>(output: &mut W) -> anyhow::Result<()> {
-    let cert = Cert::from_file(PRIV_KEY_FILE).context("failed to read private key file")?;
-    // this behaviour is not very well documented from the sequoia side. The code to
+    let cert = Cert::from_file(KEY_FILE).context("failed to read private key file")?;
+    // this behavior is not very well documented from the sequoia side. The code to
     // serialize public keys can be found in the code for the `sq` cli here: https://gitlab.com/sequoia-pgp/sequoia-sq/-/blame/main/src/commands/key/export.rs?ref_type=heads#L103
     let mut writer =
         sequoia_openpgp::armor::Writer::new(output, sequoia_openpgp::armor::Kind::PublicKey)

--- a/server/src/repository/mod.rs
+++ b/server/src/repository/mod.rs
@@ -17,7 +17,8 @@ mod manage;
 
 const REPO_DIR: &str = "repository";
 const REPO_SERENE: &str = "bases.json";
-const PRIV_KEY_FILE: &str = "sign_key.asc";
+const KEY_FILE: &str = "sign_key.asc";
+const GPG_AGENT_SOCKET: &str = "S.gpg-agent";
 
 /// returns the webservice which exposes the repository
 pub fn webservice() -> Files {


### PR DESCRIPTION
WIP: not properly tested, missing doc

decided against using the keystore since it's meant for "normal" environments with a working PGP home, proper certs, default socket paths, depends on several GPG binaries, etc.

Changes:
- `sign_key.asc` can now also be just the public key (we still need it since the agent only deals with private keys)
- if `/app/S.gpg-agent` exists then the agent will be used for cryptographic operations and only the public key portion of `sign_key.asc` will be used.

Logic if using the agent:
- read the PGP key
- connect to the GPG agent
- refresh card info
- find keys suitable for signing
- check if we have a private key for any of them in the agent and use the first suitable one (keys that require user confirmation are ignored)
- Create a keypair and optionally provide a password/pin to unlock the key
- sign as usual

the agent needs to have loopback pinentry enabled or offer keys without a password.

closes #12 

My suggestion for a setup to be included in the docs

```ini
# /etc/systemd/system/serene-gpg-agent.socket

[Unit]
Description=GnuPG cryptographic agent and passphrase cache for serene

[Socket]
ListenStream=/etc/serene/gnupg/S.gpg-agent
FileDescriptorName=std
SocketMode=0600
DirectoryMode=0700

[Install]
RequiredBy=docker.service
```
```ini
# /etc/systemd/system/serene-gpg-agent.service

[Unit]
Description=GnuPG cryptographic agent and passphrase cache for serene
Requires=serene-gpg-agent.socket

[Service]
ExecStart=/usr/bin/gpg-agent --homedir /etc/serene/gnupg --supervised
ExecReload=/usr/bin/gpgconf --homedir /etc/serene/gnupg --reload gpg-agent
```
```bash
# enable the socket
sudo systemctl enable serene-gpg-agent.socket

# test if your hardware key is detected
sudo GNUPGHOME=/etc/serene/gnupg gpg-connect-agent "LEARN --sendinfo" /bye
```
```yml
# docker-compose.yml

services:
  serene:
    # ... remaining service definition
    volumes:
      - /path/to/public-key.asc:/app/sign_key.asc
      - /etc/serene/gnupg/S.gpg-agent:/app/S.gpg-agent
      # ... other volumes
```