### PR TITLE
Remove old signatures and correct some signing references

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Many more commands are found on the documentation for the CLI:
 **[<kbd>&ensp;<br>&ensp;CLI Documentation&ensp;<br>&ensp;</kbd>](./cli/README.md)**
 
 ## State
-This project is still in its early stages, but already usable on a daily basis. There are also a couple of improvements and optimizations that still need to be implemented. 
+This project is still in its early stages, but already usable on a daily basis. There are also a couple of improvements and optimizations that still need to be implemented.
 Big, recently implemented features include:
 - [X] Entirely custom PKGBUILDs without a git repository
 - [X] Package signing
@@ -51,8 +51,8 @@ Refer to the [TODO File](TODO.md) for more features, tasks and enhancements and 
 Installing serene involves two things, deploying the server, and installing a local CLI to conveniently interact with the server.
 
 ### Deploying
-Here is a quick overview of hosting a serene server, based on the main branch. The server is just a single docker container, making it straightforward: 
-1. First, **create an empty file** called `authorized_secrets` in your directory. 
+Here is a quick overview of hosting a serene server, based on the main branch. The server is just a single docker container, making it straightforward:
+1. First, **create an empty file** called `authorized_secrets` in your directory.
 2. Set up a reverse proxy for docker (e.g. traefik) to use SSL/TLS.
 3. Add the following service to your docker compose in the same directory:
 ```yaml
@@ -94,7 +94,7 @@ If you want to use the repository without instructions from the cli, also quite 
 SigLevel = Optional TrustAll
 Server = https://your-host/x86_64
 ```
-*Signatures are not validated, as this is not yet supported. This shouldn't be an issue as we're using https and don't have any mirrors.*
+*The SigLevel should only be set to `Optional TrustAll` when [package signing](./server/README.md#package-signing) is disabled for the repository*
 
 ## Architecture
 Here's a *very* quick word about the architecture of *serene*:
@@ -103,7 +103,7 @@ Here's a *very* quick word about the architecture of *serene*:
 - **Local CLI:** Interacts with said API to add and manipulate added packages. Requires authentication via secret.
 
 ## Disclaimer
-When hosting a repository with this project, this repository is **your** responsibility! 
+When hosting a repository with this project, this repository is **your** responsibility!
 
 This means that it is your job to check `PKGBUILDs` before adding a package to the repository, as building the packages on an isolated environment does **in no way protect you from malware** if you install the package on your system. So make sure you trust the **software and AUR package maintainers** before adding it into the repository. This is especially important as the server will **automatically build new versions** without any actions from your side.
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -89,7 +89,7 @@ impl Config {
         println!();
         println!("3. To now use the repository with your pacman, add the following to your pacman configuration:");
         println!("[serene]                        # or something else if you've changed that");
-        println!("SigLevel = Optional TrustAll    # signatures are not yet supported");
+        println!("SigLevel = Optional TrustAll    # needed when package signing is disabled");
         println!("Server = {}/{}", &config.url, env::consts::ARCH);
 
         println!();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -75,6 +75,8 @@ async fn main() -> anyhow::Result<()> {
         error!("failed apply heuristics to migrate to built_state: {e:#}")
     }
 
+    repository::remove_orphan_signature().await;
+
     // schedule packages (which are enabled)
     for package in Package::find_all(&db).await?.iter().filter(|p| p.enabled) {
         schedule

--- a/server/src/package/mod.rs
+++ b/server/src/package/mod.rs
@@ -25,7 +25,7 @@ pub mod source;
 
 const SOURCE_FOLDER: &str = "sources";
 
-const PACKAGE_EXTENSION: &str = ".pkg.tar.zst"; // see /etc/makepkg.conf
+pub(crate) const PACKAGE_EXTENSION: &str = ".pkg.tar.zst"; // see /etc/makepkg.conf
 
 pub async fn add_source(
     db: &Database,

--- a/server/src/repository/manage.rs
+++ b/server/src/repository/manage.rs
@@ -8,7 +8,7 @@ fn db_file(name: &str) -> String {
     format!("{name}.db.tar.gz")
 }
 
-fn sig_path(path: &Path) -> PathBuf {
+pub(crate) fn sig_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(
         "{}.sig",
         path.file_name().unwrap_or_default().to_str().unwrap_or_default()

--- a/server/src/repository/mod.rs
+++ b/server/src/repository/mod.rs
@@ -102,8 +102,19 @@ impl PackageRepository {
 
             // delete package files
             for entry in entries {
-                if let Err(e) = fs::remove_file(Path::new(REPO_DIR).join(&entry.file)).await {
+                let package_path = Path::new(REPO_DIR).join(&entry.file);
+                if let Err(e) = fs::remove_file(&package_path).await {
                     warn!("failed to delete file from repository ({e}): {}", entry.file);
+                }
+
+                let signature_path = manage::sig_path(&package_path);
+                if signature_path.exists() {
+                    if let Err(e) = fs::remove_file(&signature_path).await {
+                        warn!(
+                            "failed to delete signature file from repository ({e}): {}.sig",
+                            entry.file
+                        );
+                    }
                 }
             }
         }

--- a/server/src/repository/mod.rs
+++ b/server/src/repository/mod.rs
@@ -1,12 +1,12 @@
 use crate::config::CONFIG;
-use crate::package::Package;
+use crate::package::{Package, PACKAGE_EXTENSION};
 use crate::runner::archive;
 use actix_files::Files;
 use anyhow::{anyhow, Context};
 use async_tar::Entries;
 use futures_util::AsyncRead;
 use hyper::body::HttpBody;
-use log::warn;
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -19,6 +19,42 @@ const REPO_DIR: &str = "repository";
 const REPO_SERENE: &str = "bases.json";
 const KEY_FILE: &str = "sign_key.asc";
 const GPG_AGENT_SOCKET: &str = "S.gpg-agent";
+
+/// see https://github.com/VirtCode/serene-aur/pull/18
+pub async fn remove_orphan_signature() {
+    let Ok(dir) = std::fs::read_dir(REPO_DIR) else {
+        warn!("REPOSITORY DIRECTORY DOES NOT EXIST??");
+        // repository directory does not yet exist -> no orphan signatures can exist
+        return;
+    };
+
+    let mut deleted = 0;
+
+    dir.into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path().is_file()
+                && e.path().to_string_lossy().ends_with(format!("{PACKAGE_EXTENSION}.sig").as_str())
+        })
+        .for_each(|entry| {
+            if let Some(path) = entry.path().file_stem() {
+                if !Path::new(REPO_DIR).join(path).exists() {
+                    if let Err(e) = std::fs::remove_file(entry.path()) {
+                        warn!(
+                            "failed to delete orphan signature file from repository ({e}): {}",
+                            entry.path().to_string_lossy()
+                        );
+                    } else {
+                        deleted += 1;
+                    }
+                }
+            }
+        });
+
+    if deleted > 0 {
+        info!("pruned {deleted} orphan signature file(s) from repository");
+    }
+}
 
 /// returns the webservice which exposes the repository
 pub fn webservice() -> Files {

--- a/server/src/repository/mod.rs
+++ b/server/src/repository/mod.rs
@@ -23,7 +23,6 @@ const GPG_AGENT_SOCKET: &str = "S.gpg-agent";
 /// see https://github.com/VirtCode/serene-aur/pull/18
 pub async fn remove_orphan_signature() {
     let Ok(dir) = std::fs::read_dir(REPO_DIR) else {
-        warn!("REPOSITORY DIRECTORY DOES NOT EXIST??");
         // repository directory does not yet exist -> no orphan signatures can exist
         return;
     };


### PR DESCRIPTION
When a package was rebuilt or updated the old signature didn't get cleaned up. This caused a lot of orphaned signatures in the repository. Those signatures now get correctly deleted.

Additionally, in the onboarding and the README was text which stated package signing isn't supported yet. Since this is no longer the case I adjusted those text to be more fitting.