### PR TITLE
Use correct SSE format

### DIFF
--- a/server/data/Cargo.toml
+++ b/server/data/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # serialization
-serde = { version = "1.0.193", features = ["derive"]}
+serde = { version = "1.0.193", features = ["derive"] }
 chrono = { version = "0.4.31", features = ["serde"] }
 
 # secret

--- a/server/data/src/package.rs
+++ b/server/data/src/package.rs
@@ -174,7 +174,7 @@ pub struct PackageInfo {
 
 /// All events which can be emitted by the broadcast for a package
 #[derive(Serialize, Deserialize, Display, Clone)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", tag = "event", content = "data")]
 pub enum BroadcastEvent {
     /// Change in the package build state
     Change(BuildState),
@@ -182,4 +182,15 @@ pub enum BroadcastEvent {
     Log(String),
     /// Ping to the event subscriber
     Ping,
+}
+
+impl BroadcastEvent {
+    /// Name of the SSE event
+    pub fn name(&self) -> &'static str {
+        match self {
+            BroadcastEvent::Change { .. } => "change",
+            BroadcastEvent::Log { .. } => "log",
+            BroadcastEvent::Ping => "ping",
+        }
+    }
 }

--- a/server/src/web/broadcast.rs
+++ b/server/src/web/broadcast.rs
@@ -59,11 +59,7 @@ impl Broadcast {
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-            if !receivers.is_empty() {
-                Some((package.clone(), receivers))
-            } else {
-                None
-            }
+            if !receivers.is_empty() { Some((package.clone(), receivers)) } else { None }
         }))
         .await
         .into_iter()
@@ -156,6 +152,10 @@ impl Broadcast {
 
     /// create a sse event for a package and an event
     fn create_event(package: &str, event: BroadcastEvent) -> Option<Event> {
-        serde_json::to_string(&event).map(|event| Event::Data(Data::new(event).event(package))).ok()
+        serde_json::to_value(&event)
+            .map(|value| {
+                Event::Data(Data::new(value["data"].to_string()).id(package).event(event.name()))
+            })
+            .ok()
     }
 }


### PR DESCRIPTION
This does not actually add better logs (as the branch name would suggest) but the server sent events are now much better.
We now no longer serialize the full event as json into the `data` field but instead use
- the `id` field for the package name
- the `event` field for the event name (e.g. ping, log)
- the `data` field for the content (body) of the event in json serialized form
